### PR TITLE
Make pegjs AMD-compatible

### DIFF
--- a/src/peg.js
+++ b/src/peg.js
@@ -37,6 +37,8 @@ PEG.GrammarError.prototype = Error.prototype;
 
 if (typeof module === "object") {
   module.exports = PEG;
+} else if (typeof define === 'function' && define.amd) {
+  define(PEG);
 } else if (typeof window === "object") {
   window.PEG = PEG;
 } else {


### PR DESCRIPTION
Here's a start.

The `pegjs` command-line tool still needs to be updated to spit out AMD-compatible code.
