### PR TITLE
parsing octl like string literal may cause exception.

### DIFF
--- a/examples/javascript.pegjs
+++ b/examples/javascript.pegjs
@@ -273,6 +273,7 @@ EscapeSequence
   = CharacterEscapeSequence
   / "0" !DecimalDigit { return "\0"; }
   / HexEscapeSequence
+  / OCTLEscapeSequence
   / UnicodeEscapeSequence
 
 CharacterEscapeSequence
@@ -302,6 +303,11 @@ EscapeCharacter
 HexEscapeSequence
   = "x" h1:HexDigit h2:HexDigit {
       return String.fromCharCode(parseInt("0x" + h1 + h2));
+    }
+
+OCTLEscapeSequence
+  = o1:DecimalDigit o2:DecimalDigit? o3:DecimalDigit? {
+      return String.fromCharCode(parseInt(o1 + (o2 || '') + (o3 || ''), 8));
     }
 
 UnicodeEscapeSequence


### PR DESCRIPTION
there is a little bug in `example/javascript.pegjs`, since javascript support "OCTL: the C/Modula-3 octal notation" kind of string (`\XXX`), and this example only provided hex (\xXX) and unicode(\uXXXX) like escape parsing, parse exception maybe throw when parsing OCTL like string literal.

```
echo "'\341'" > testfile
pegjs javascript.pegjs
node -e "console.log(require('./javascript').parse(require('fs').readFileSync('./testfile').toString()))"
```

then this exception will be throw:

```
throw new this.SyntaxError(
          ^
SyntaxError: Expected "!", "(", "+", "++", "-", "--", ";", "[", "break", "continue", "debugger", "delete", "do", "false", "for", "function", "if", "new", "null", "return", "switch", "this", "throw", "true", "try", "typeof", "var", "void", "while", "with", "{", "~", comment, end of line, identifier, number, regular expression, string or whitespace but "\"" found.
```

add `OCTLEscapeSequence` to `EscapeSequence` can fix this.
