### PR TITLE
pegjs --wrapper-template option

### DIFF
--- a/bin/pegjs
+++ b/bin/pegjs
@@ -23,6 +23,9 @@ function printHelp() {
   util.puts("Options:");
   util.puts("  -e, --export-var <variable>  name of the variable where the parser object");
   util.puts("                               will be stored (default: \"module.exports\")");
+  util.puts("      --wrapper-template       provide wrapper template for generated code");
+  util.puts("                               using %s as a placeholder, -e/--export-var");
+  util.puts("                               option will ignored if this options is present");
   util.puts("      --cache                  make generated parser cache results");
   util.puts("      --track-line-and-column  make generated parser track line and column");
   util.puts("  -v, --version                print version information and exit");
@@ -66,6 +69,7 @@ function readStream(inputStream, callback) {
 
 /* This makes the generated parser a CommonJS module by default. */
 var exportVar = "module.exports";
+var templateWrapper = undefined;
 var options = {
   cache:              false,
   trackLineAndColumn: false
@@ -80,6 +84,14 @@ while (args.length > 0 && isOption(args[0])) {
         abort("Missing parameter of the -e/--export-var option.");
       }
       exportVar = args[0];
+      break;
+
+    case "--wrapper-template":
+      nextArg();
+      if (args.length === 0) {
+        abort("Missing parameter of the --template-wrapper option.");
+      }
+      templateWrapper = args[0];
       break;
 
     case "--cache":
@@ -152,7 +164,11 @@ readStream(inputStream, function(input) {
     }
   }
 
-  outputStream.write(exportVar + " = " + parser.toSource() + ";\n");
+  if (templateWrapper !== undefined) {
+    outputStream.write(templateWrapper.replace("%s", parser.toSource()));
+  } else {
+    outputStream.write(exportVar + " = " + parser.toSource() + ";\n");
+  }
   if (outputStream !== process.stdout) {
     outputStream.end();
   }


### PR DESCRIPTION
Allows to wrap generated parser code into arbitrary wrapper. Maybe useful, for
example, to implement AMD module or providing simultaneous support for both AMD
and CommonJS. Example usage for producing AMD module with parser:

  pegjs --wrapper-template 'define(%s);'
