### PR TITLE
TypeError: Object has no method 'charCodeAt'

### DIFF
--- a/src/compiler/passes/generate-code.js
+++ b/src/compiler/passes/generate-code.js
@@ -306,6 +306,7 @@ PEG.compiler.passes.generateCode = function(ast, options) {
             '     * unsuccessful, throws |PEG.parser.SyntaxError| describing the error.',
             '     */',
             '    parse: function(input) {',
+            '      input = String(input);',
             '      var parseFunctions = {',
             '        #for rule in node.rules',
             '          #{string(rule.name) + ": parse_" + rule.name + (rule !== node.rules[node.rules.length - 1] ? "," : "")}',


### PR DESCRIPTION
Tiny change to fix the error message TypeError: Object has no method 'charCodeAt' when input is a numeric value.
