### PR TITLE
Output pure parser source for empty `--export-var`

### DIFF
--- a/bin/pegjs
+++ b/bin/pegjs
@@ -180,7 +180,7 @@ readStream(inputStream, function(input) {
   if (exportVar) {
     source = exportVar + " = " + source;
   }
-  source += ";"
+  source += ";";
 
   outputStream.write(source + "\n");
   if (outputStream !== process.stdout) {


### PR DESCRIPTION
If the command line specifies `pegjs --export-var ''`, it should only output pure parser source.

One use case is to write a template file

```
var parser = @CONTENT
```

and then replace `@CONTENT` with the generated parser source with another tool.

This mitigates #140
