### PR TITLE
using s(0) instead of hardcoded s0

### DIFF
--- a/lib/compiler/passes/generate-javascript.js
+++ b/lib/compiler/passes/generate-javascript.js
@@ -649,7 +649,7 @@ module.exports = function(ast, options) {
 
     parts.push([
       '',
-      '  return s0;',
+      '  return '+s(0)+';',
       '}'
     ].join('\n'));
 


### PR DESCRIPTION
Its more maintainable (changing the definition of s breaks things without this change).
Note: I don't know what `generateCacheFooter('s0')` does and the s0 in there looks suspicious to me
