### PR TITLE
Ignore `undefined` value for options object and `startRule` option

### DIFF
--- a/lib/compiler/passes/generate-javascript.js
+++ b/lib/compiler/passes/generate-javascript.js
@@ -797,7 +797,7 @@ module.exports = function(ast, options) {
 
   if (options.optimize === "size") {
     parts.push([
-      '    if ("startRule" in options) {',
+      '    if (options.startRule !== undefined) {',
       '      if (!(options.startRule in peg$startRuleIndices)) {',
       '        throw new Error("Can\'t start parsing from rule \\"" + options.startRule + "\\".");',
       '      }',
@@ -807,7 +807,7 @@ module.exports = function(ast, options) {
     ].join('\n'));
   } else {
     parts.push([
-      '    if ("startRule" in options) {',
+      '    if (options.startRule !== undefined) {',
       '      if (!(options.startRule in peg$startRuleFunctions)) {',
       '        throw new Error("Can\'t start parsing from rule \\"" + options.startRule + "\\".");',
       '      }',


### PR DESCRIPTION
So calling parse like this will use the default options instead

```
var options = {};
parser.parse(input, options.pegOptions);
```

And  calling parser like this will use default `startRule` option instead

```
var options = {};
parser.parse(input, {startRule: options.startRule});
```
