### PR TITLE
Fix automatic semi-colon insertion

### DIFF
--- a/examples/javascript.pegjs
+++ b/examples/javascript.pegjs
@@ -1164,20 +1164,20 @@ VariableDeclarationListNoIn
     }
 
 VariableDeclaration
-  = name:Identifier __ value:Initialiser? {
+  = name:Identifier value:(__ Initialiser)? {
       return {
         type:  "VariableDeclaration",
         name:  name,
-        value: value !== "" ? value : null
+        value: value !== "" ? value[1] : null
       };
     }
 
 VariableDeclarationNoIn
-  = name:Identifier __ value:InitialiserNoIn? {
+  = name:Identifier value:(__ InitialiserNoIn)? {
       return {
         type:  "VariableDeclaration",
         name:  name,
-        value: value !== "" ? value : null
+        value: value !== "" ? value[1] : null
       };
     }
 


### PR DESCRIPTION
Fix automatic semi-colon insertion in var statements without
initialisers.
var i
i = 1;
is valid and not accepted by the parser

but
var i = 2
i = 3;
is valid and accepted by the parser, as it should be.

With this fix, both are accepted.
