### PR TITLE
Add a three-stage bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ JSHINT        = $(NODE_MODULES_BIN_DIR)/jshint
 UGLIFYJS      = $(NODE_MODULES_BIN_DIR)/uglifyjs
 JASMINE_NODE  = $(NODE_MODULES_BIN_DIR)/jasmine-node
 PEGJS         = $(BIN_DIR)/pegjs
+PEGJS_BOOT    = $(BIN_DIR)/pegjs
 BENCHMARK_RUN = $(BENCHMARK_DIR)/run
 
 # ===== Targets =====
@@ -54,7 +55,13 @@ all: browser
 # Generate the grammar parser
 parser: $(PARSER_OUT_FILE)
 $(PARSER_OUT_FILE): $(PARSER_SRC_FILE)
-	$(PEGJS) $< $@
+	$(PEGJS_BOOT) $< $@1.js
+	cp $@1.js $@
+	$(PEGJS) $< $@2.js
+	cp $@2.js $@
+	$(PEGJS) $< $@3.js
+	cmp $@2.js $@3.js
+	rm $@*.js
 
 # Build the browser version of the library
 browser: $(BROWSER_FILE_MIN)


### PR DESCRIPTION
This adds a proper three-stage build process for the lib/parser.js file. This is how compilers generally build themselves, first by building the new generator from an old one, then building a new second stage one from the first stage, then building a third stage and ensuring it is identical to the second stage build.

This process removes any last traces of circular dependencies, and will ensure in the future that no bugs will creep their way down the compiled versions even after they've been removed from the source code.

This commit also leaves open the option of removing lib/parser.js from the repository entirely. I opted not to, because doing so would require finding a working build of pegjs somewhere (even if an old version). Normally I would opt to leave out compiled code, but seeing as this saves a significant amount of work I don't see a problem with leaving it in.
