### PR TITLE
Allow the Cache Option to Set the Cache Object

### DIFF
--- a/lib/compiler/passes/generate-javascript.js
+++ b/lib/compiler/passes/generate-javascript.js
@@ -40,8 +40,9 @@ module.exports = function(ast, options) {
 
   function generateCacheHeader(ruleIndexCode) {
     return [
-      'var key    = peg$currPos * ' + ast.rules.length + ' + ' + ruleIndexCode + ',',
-      '    cached = peg$cache[key];',
+      'var startPos = peg$currPos,',
+      '    key      = peg$currPos * ' + ast.rules.length + ' + ' + ruleIndexCode + ',',
+      '    cached   = peg$cache[key];',
       '',
       'if (cached) {',
       '  peg$currPos = cached.nextPos;',
@@ -54,7 +55,7 @@ module.exports = function(ast, options) {
   function generateCacheFooter(resultCode) {
     return [
       '',
-      'peg$cache[key] = { nextPos: peg$currPos, result: ' + resultCode + ' };'
+      'peg$cache[key] = { currPos: startPos, nextPos: peg$currPos, result: ' + resultCode + ' };'
     ].join('\n');
   }
 


### PR DESCRIPTION
It can be useful to use the same `peg$cache` object between parser runs. This modifies the generated javascript for the parser so that when the `cache` option is an object, that object is used instead of a new one. The parser has also been changed to include the start position of every cache entry.
