### PR TITLE
allow access to result in code

### DIFF
--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -186,7 +186,7 @@ module.exports = function(ast, options) {
 
   function addFunctionConst(params, code) {
     return addConst(
-      "function(" + params.concat(['__result']).join(", ") + ") {" + code + "}"
+      "function(" + params.concat(['__result', '__ruleName']).join(", ") + ") {" + code + "}"
     );
   }
 

--- a/lib/compiler/passes/generate-javascript.js
+++ b/lib/compiler/passes/generate-javascript.js
@@ -427,6 +427,7 @@ module.exports = function(ast, options) {
           stackIndex
         );
         params.push('[' + utils.map(utils.range(1, stack.sp + 1), s) + ']');
+        params.push("'" + rule.name + "'");
 
         var value = c(bc[ip + 1]) + '(' + params.join(', ') + ')';
         stack.pop(bc[ip + 2]);

--- a/spec/compiler/passes/generate-bytecode.spec.js
+++ b/spec/compiler/passes/generate-bytecode.spec.js
@@ -102,7 +102,7 @@ describe("compiler pass |generateBytecode|", function() {
       it("defines correct constants", function() {
         expect(pass).toChangeAST(
           grammar,
-          constsDetails(['[]', 'function(__result) { code }'])
+          constsDetails(['[]', 'function(__result, __ruleName) { code }'])
         );
       });
     });
@@ -126,7 +126,7 @@ describe("compiler pass |generateBytecode|", function() {
       it("defines correct constants", function() {
         expect(pass).toChangeAST(
           grammar,
-          constsDetails(['"a"', '"\\"a\\""', 'function(a, __result) { code }'])
+          constsDetails(['"a"', '"\\"a\\""', 'function(a, __result, __ruleName) { code }'])
         );
       });
     });
@@ -168,7 +168,7 @@ describe("compiler pass |generateBytecode|", function() {
           '"\\"b\\""',
           '"c"',
           '"\\"c\\""',
-          'function(a, b, c, __result) { code }'
+          'function(a, b, c, __result, __ruleName) { code }'
         ]));
       });
     });
@@ -325,7 +325,7 @@ describe("compiler pass |generateBytecode|", function() {
       it("defines correct constants", function() {
         expect(pass).toChangeAST(
           grammar,
-          constsDetails(['function(__result) { code }', '""', 'null'])
+          constsDetails(['function(__result, __ruleName) { code }', '""', 'null'])
         );
       });
     });
@@ -376,7 +376,7 @@ describe("compiler pass |generateBytecode|", function() {
           '"\\"b\\""',
           '"c"',
           '"\\"c\\""',
-          'function(a, b, c, __result) { code }',
+          'function(a, b, c, __result, __ruleName) { code }',
           '""'
         ]));
       });
@@ -402,7 +402,7 @@ describe("compiler pass |generateBytecode|", function() {
       it("defines correct constants", function() {
         expect(pass).toChangeAST(
           grammar,
-          constsDetails(['function(__result) { code }', '""', 'null'])
+          constsDetails(['function(__result, __ruleName) { code }', '""', 'null'])
         );
       });
     });
@@ -453,7 +453,7 @@ describe("compiler pass |generateBytecode|", function() {
           '"\\"b\\""',
           '"c"',
           '"\\"c\\""',
-          'function(a, b, c, __result) { code }',
+          'function(a, b, c, __result, __ruleName) { code }',
           '""'
         ]));
       });


### PR DESCRIPTION
When an expression has an action, currently the function only receives the named expressions.
This pull request adds a `__result` argument, so that one has access to each and every match.

No breaking changes.

E.g.

```
HTTP_version
  = "HTTP" "/" DIGIT "." DIGIT
  { return {
    major: __result[2],
    minor: __result[4]
  } }

DIGIT
  = [0-9]

```

Thoughts?

UPDATE: this also adds a `__ruleName` argument, so that one can create generic actions.
