### PR TITLE
Allow labels to propagate though sub-expressions

### DIFF
--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -221,7 +221,7 @@ module.exports = function(ast, options) {
       [op.SILENT_FAILS_ON],
       generate(expression, {
         sp:     context.sp + 1,
-        env:    { },
+        env:    utils.clone(context.env),
         action: null
       }),
       [op.SILENT_FAILS_OFF],
@@ -307,7 +307,7 @@ module.exports = function(ast, options) {
         return buildSequence(
           generate(alternatives[0], {
             sp:     context.sp,
-            env:    { },
+            env:    utils.clone(context.env),
             action: null
           }),
           alternatives.length > 1
@@ -327,7 +327,7 @@ module.exports = function(ast, options) {
     },
 
     action: function(node, context) {
-      var env            = { },
+      var env            = utils.clone(context.env),
           emitCall       = node.expression.type !== "sequence"
                         || node.expression.elements.length === 0;
           expressionCode = generate(node.expression, {
@@ -425,7 +425,7 @@ module.exports = function(ast, options) {
 
       return generate(node.expression, {
         sp:     context.sp,
-        env:    { },
+        env:    utils.clone(context.env),
         action: null
       });
     },
@@ -435,7 +435,7 @@ module.exports = function(ast, options) {
         [op.PUSH_CURR_POS],
         generate(node.expression, {
           sp:     context.sp + 1,
-          env:    { },
+          env:    utils.clone(context.env),
           action: null
         }),
         buildCondition([op.IF_NOT_ERROR], [op.TEXT], []),
@@ -465,7 +465,7 @@ module.exports = function(ast, options) {
       return buildSequence(
         generate(node.expression, {
           sp:     context.sp,
-          env:    { },
+          env:    utils.clone(context.env),
           action: null
         }),
         buildCondition(
@@ -480,7 +480,7 @@ module.exports = function(ast, options) {
       var emptyArrayIndex = addConst('[]');
           expressionCode  = generate(node.expression, {
             sp:     context.sp + 1,
-            env:    { },
+            env:    utils.clone(context.env),
             action: null
           });
 
@@ -497,7 +497,7 @@ module.exports = function(ast, options) {
           nullIndex       = addConst('null');
           expressionCode  = generate(node.expression, {
             sp:     context.sp + 1,
-            env:    { },
+            env:    utils.clone(context.env),
             action: null
           });
 


### PR DESCRIPTION
That is an example of doing lua style comments in peg.js, which is currently impossible without a lot of creative work.