### PR TITLE
Add initializer example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,32 @@ braces (“{” and “}”). This code is executed before the generated parser 
 parsing. All variables and functions defined in the initializer are accessible
 in rule actions and semantic predicates. The code inside the initializer can
 access options passed to the parser using the `options` variable. Curly braces
-in the initializer code must be balanced.
+in the initializer code must be balanced. Let's look at the example grammar 
+from above using a simple initializer.
+
+    {
+      function makeInteger(o) {
+        return parseInt(o.join(""), 10);
+      }
+    }
+
+    start
+      = additive
+
+    additive
+      = left:multiplicative "+" right:additive { return left + right; }
+      / multiplicative
+
+    multiplicative
+      = left:primary "*" right:multiplicative { return left * right; }
+      / primary
+
+    primary
+      = integer
+      / "(" additive:additive ")" { return additive; }
+
+    integer "integer"
+      = digits:[0-9]+ { return makeInteger(digits); }
 
 The parsing expressions of the rules are used to match the input text to the
 grammar. There are various types of expressions — matching characters or


### PR DESCRIPTION
I personally found the existing documentation a little confusing with regards to initializers. I thought a simple example would make it a little more clear how and where to declare them.
