### PR TITLE
Add whitespace to generated action calls

### DIFF
--- a/lib/compiler/passes/generate-javascript.js
+++ b/lib/compiler/passes/generate-javascript.js
@@ -426,7 +426,7 @@ module.exports = function(ast, options) {
               + utils.map(
                   bc.slice(ip + baseLength, ip + baseLength + paramsLength),
                   stackIndex
-                )
+                ).join(', ')
               + ')';
         stack.pop(bc[ip + 2]);
         parts.push(stack.push(value));


### PR DESCRIPTION
Avoids implicit array to string conversion.
