### PR TITLE
upgrade jasmine-node and fix node 0.10+ version detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "url":  "http://github.com/dmajda/pegjs.git"
   },
   "devDependencies": {
-    "jasmine-node": "= 1.0.26",
+    "jasmine-node": "= 1.11.0",
     "uglify-js":    "= 1.3.4",
     "jshint":       "= 0.9.1"
   },


### PR DESCRIPTION
jasmine-node pre 1.4 has a problem with detecting nodejs versions that use two digits for minor, thus fails on e.g. 0.10

```
node_modules/jasmine-node/lib/jasmine-node/index.js:21
var minorVersion = process.version.match(/\d.(\d).\d/)[1];
^
TypeError:
Cannot read property
'1' of null
```
