### PR TITLE
Makefile tweaks to support packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,9 @@ VERSION_FILE = VERSION
 
 # ===== Executables =====
 
-JSHINT        = $(NODE_MODULES_BIN_DIR)/jshint
-UGLIFYJS      = $(NODE_MODULES_BIN_DIR)/uglifyjs
-JASMINE_NODE  = $(NODE_MODULES_BIN_DIR)/jasmine-node
+JSHINT        ?= $(NODE_MODULES_BIN_DIR)/jshint
+UGLIFYJS      ?= $(NODE_MODULES_BIN_DIR)/uglifyjs
+JASMINE_NODE  ?= $(NODE_MODULES_BIN_DIR)/jasmine-node
 PEGJS         = $(BIN_DIR)/pegjs
 BENCHMARK_RUN = $(BENCHMARK_DIR)/run
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 
 PEGJS_VERSION = `cat $(VERSION_FILE)`
 
+DIST_NAME = pegjs
+DIST_VERSION = $(PEGJS_VERSION)
+DIST_BASE = $(DIST_NAME)-$(DIST_VERSION)
+
 # ===== Modules =====
 
 # Order matters -- dependencies must be listed before modules dependent on them.
@@ -128,6 +132,18 @@ hint:
 	  $(BENCHMARK_DIR)/*.js                                                  \
 	  $(BENCHMARK_RUN)                                                       \
 	  $(PEGJS)
+
+# Make a distribution tarball for packaging
+# Note: we don't currently include the benchmark tree in the dist tarball
+# because it contains non-human-readable jQuery artifacts and this can
+# be an impediment to distribution in free software archives such as
+# Debian and Fedora.
+# Run the benchmark from git if required.
+dist:
+	-rm -rf $(DIST_BASE)
+	mkdir $(DIST_BASE)
+	cp -r bin CHANGELOG examples lib LICENSE Makefile package.json README.md spec src tools VERSION $(DIST_BASE)
+	tar czf $(DIST_BASE).tar.gz $(DIST_BASE)
 
 .PHONY:  all parser browser browserclean spec benchmark hint
 .SILENT: all parser browser browserclean spec benchmark hint


### PR DESCRIPTION
Hi,

I'm going to package your project, PEG.js, for Debian

I needed to make a couple of small tweaks to the Makefile, this allows us to create a source tarball for distribution on the Debian source DVD.  That means somebody without a network connection will be able to build it completely offline.

Regards,

Daniel