### PR TITLE
Improve report-left-recursion performance, do not create a new array copy at each step

### DIFF
--- a/lib/compiler/passes/report-left-recursion.js
+++ b/lib/compiler/passes/report-left-recursion.js
@@ -22,7 +22,9 @@ module.exports = function(ast) {
 
     rule:
       function(node, appliedRules) {
-        check(node.expression, appliedRules.concat(node.name));
+        appliedRules.push(node.name);
+        check(node.expression, appliedRules);
+        appliedRules.pop();
       },
 
     named:       checkExpression,


### PR DESCRIPTION
`report-left-recursion.js` compile step can require excessive amounts of time for some grammars. Almost 50% of that time is spent copying arrays around, fixed by this change.