### PR TITLE
Added ruleName() function which can be called inside semantic actions to return the currently executing rule

### DIFF
--- a/lib/compiler/passes/generate-javascript.js
+++ b/lib/compiler/passes/generate-javascript.js
@@ -592,6 +592,7 @@ module.exports = function(ast, options) {
 
           case op.REPORT_SAVED_POS: // REPORT_SAVED_POS p
             parts.push('peg$reportedPos = ' + stack.index(bc[ip + 1]) + ';');
+            parts.push('peg$currentRule = peg$currentRuleName;');
             ip += 2;
             break;
 
@@ -631,6 +632,7 @@ module.exports = function(ast, options) {
 
     parts.push([
       'function peg$parse' + rule.name + '() {',
+      '  var peg$currentRuleName = \'' + rule.name + '\';',
       '  var ' + utils.map(utils.range(0, stack.maxSp + 1), s).join(', ') + ';',
       ''
     ].join('\n'));
@@ -783,6 +785,7 @@ module.exports = function(ast, options) {
     '        peg$maxFailPos       = 0,',
     '        peg$maxFailExpected  = [],',
     '        peg$silentFails      = 0,', // 0 = report failures, > 0 = silence failures
+    '        peg$currentRule      = null,',
     ''
   ].join('\n'));
 
@@ -821,6 +824,10 @@ module.exports = function(ast, options) {
     '',
     '    function text() {',
     '      return input.substring(peg$reportedPos, peg$currPos);',
+    '    }',
+    '',
+    '    function ruleName() {',
+    '      return peg$currentRule;',
     '    }',
     '',
     '    function offset() {',


### PR DESCRIPTION
Saw mention of this as a desired feature in the issues list, and found myself needing it as well.  Not sure whether this is the most desired approach vs. storing a separate string table and using a numeric type for rule_id lookup.