### PR TITLE
Allow any defined rule as an allowed start rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ You can tweak the generated parser with several options:
   * `--cache` — makes the parser cache results, avoiding exponential parsing
     time in pathological cases but making the parser slower
   * `--allowed-start-rules` — comma-separated list of rules the parser will be
-    allowed to start parsing from (default: the first rule in the grammar)
+    allowed to start parsing from, or * to allow all rules (default: the
+    first rule in the grammar)
   * `--plugin` — makes PEG.js use a specified plugin (can be specified multiple
     times)
   * `--extra-options` — additional options (in JSON format) to pass to
@@ -110,7 +111,7 @@ object to `PEG.buildParser`. The following options are supported:
     parsing time in pathological cases but making the parser slower (default:
     `false`)
   * `allowedStartRules` — rules the parser will be allowed to start parsing from
-    (default: the first rule in the grammar)
+    or * to allow all (default: the first rule in the grammar)
   * `output` — if set to `"parser"`, the method will return generated parser
     object; if set to `"source"`, it will return parser source code as a string
     (default: `"parser"`)

--- a/bin/pegjs
+++ b/bin/pegjs
@@ -138,6 +138,9 @@ while (args.length > 0 && isOption(args[0])) {
       options.allowedStartRules = args[0]
         .split(",")
         .map(trim);
+      if (args[0] === "*") {
+        options.allowedStartRules = options.allowedStartRules[0];
+      }
       break;
 
     case "-o":

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -47,6 +47,10 @@ module.exports = {
       output:             "parser"
     });
 
+    if (options.allowedStartRules === "*") {
+      options.allowedStartRules = ast.rules.map(function(rule) { return rule.name; });
+    }
+
     for (stage in passes) {
       if (passes.hasOwnProperty(stage)) {
         utils.each(passes[stage], runPass);

--- a/spec/generated-parser.spec.js
+++ b/spec/generated-parser.spec.js
@@ -143,11 +143,13 @@ describe("generated parser", function() {
   });
 
   describe("parse", function() {
-    var parser = PEG.buildParser([
-          'a = "x" { return "a"; }',
-          'b = "x" { return "b"; }',
-          'c = "x" { return "c"; }'
-        ].join("\n"), { allowedStartRules: ["b", "c"] });
+    var grammar = [
+      'a = "x" { return "a"; }',
+      'b = "x" { return "b"; }',
+      'c = "x" { return "c"; }'
+    ].join("\n"),
+        parser = PEG.buildParser(grammar, { allowedStartRules: ["b", "c"] }),
+        parserAll = PEG.buildParser(grammar, { allowedStartRules: "*" });
 
     describe("start rule", function() {
       describe("without the |startRule| option", function() {
@@ -169,6 +171,14 @@ describe("generated parser", function() {
             message: "Can't start parsing from rule \"a\"."
           });
         });
+      });
+    });
+
+    describe("wildcard start rule", function() {
+      it("uses any rule", function() {
+        expect(parserAll).toParse("x", { startRule: "a" }, "a");
+        expect(parserAll).toParse("x", { startRule: "b" }, "b");
+        expect(parserAll).toParse("x", { startRule: "c" }, "c");
       });
     });
   });


### PR DESCRIPTION
If allowedStartRule is the wildcard (i.e. "*"), then any defined rule
can be used as as startRule for the parser.

Fixes https://github.com/dmajda/pegjs/issues/234