### PR TITLE
(feature) require label names to be unique within a rule (issue #270)

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -11,15 +11,16 @@ var compiler = {
    */
   passes: {
     check: {
-      reportMissingRules:  require("./compiler/passes/report-missing-rules"),
-      reportLeftRecursion: require("./compiler/passes/report-left-recursion")
+      reportMissingRules:     require("./compiler/passes/report-missing-rules"),
+      reportLeftRecursion:    require("./compiler/passes/report-left-recursion"),
+      reportDuplicateLabels:  require("./compiler/passes/report-duplicate-labels")
     },
     transform: {
-      removeProxyRules:    require("./compiler/passes/remove-proxy-rules")
+      removeProxyRules:       require("./compiler/passes/remove-proxy-rules")
     },
     generate: {
-      generateBytecode:    require("./compiler/passes/generate-bytecode"),
-      generateJavascript:  require("./compiler/passes/generate-javascript")
+      generateBytecode:       require("./compiler/passes/generate-bytecode"),
+      generateJavascript:     require("./compiler/passes/generate-javascript")
     }
   },
 

--- a/lib/compiler/passes/report-duplicate-labels.js
+++ b/lib/compiler/passes/report-duplicate-labels.js
@@ -1,0 +1,28 @@
+var GrammarError = require("../../grammar-error"),
+    visitor      = require("../visitor");
+
+/* Checks that there are no duplicate labels within a rule. */
+function reportDuplicateLabels(ast) {
+  var check = visitor.build({
+    rule: function(node, data) {
+      check(node.expression, {
+        nodeName: node.name,
+        labels: {}
+      });
+    },
+
+    labeled: function(node, data) {
+      if (data.labels.hasOwnProperty(node.label)) {
+        throw new GrammarError(
+          'Duplicate label \"' + node.label + '\" detected for rule \"' + data.nodeName + '\".'
+        );
+      }
+
+      data.labels[node.label] = 1;
+    }
+  });
+
+  check(ast);
+}
+
+module.exports = reportDuplicateLabels;

--- a/spec/unit/compiler/passes/report-duplicate-labels.spec.js
+++ b/spec/unit/compiler/passes/report-duplicate-labels.spec.js
@@ -1,0 +1,35 @@
+describe("compiler pass |reportDuplicateLabels|", function() {
+  var pass = PEG.compiler.passes.check.reportDuplicateLabels;
+  var msg = 'Duplicate label "a" detected for rule "start".';
+
+  it("reports duplicate labels", function() {
+    expect(pass).toReportError("start = a:'some' a:'thing'", {
+      message: msg
+    });
+  });
+
+  it("reports duplicate labels inside expressions", function() {
+    expect(pass).toReportError("start = (a:'some')* a:'thing'", {
+      message: msg
+    });
+
+    expect(pass).toReportError("start = a:'some' / a:'thing'", {
+      message: msg
+    });
+
+    expect(pass).toReportError("start = ('some' / a:'other')+ / a:'thing'", {
+      message: msg
+    });
+  });
+
+  it("allows unique labels", function() {
+    expect(pass).not.toReportError("start = a:'some' b:'thing'");
+  });
+
+  it("allows identical labels on different rules", function() {
+    expect(pass).not.toReportError([
+      "start = a:'some' thing",
+      "thing = a:'thing'"
+    ].join('\n'));
+  });
+});


### PR DESCRIPTION
Add a new compiler pass to check if label names within a rule are unique.
Report any duplicate labels as a GrammarError.