### PR TITLE
Revert "PEG.js grammar: Disallow empty sequences"

### DIFF
--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -414,14 +414,14 @@ function generateBytecode(ast) {
         }
       }
 
-      return buildSequence(
+      return node.elements.length > 0 ? buildSequence(
         [op.PUSH_CURR_POS],
         buildElementsCode(node.elements, {
           sp:     context.sp + 1,
           env:    context.env,
           action: context.action
         })
-      );
+      ) : [op.PUSH_EMPTY_ARRAY];
     },
 
     labeled: function(node, context) {

--- a/lib/compiler/passes/report-left-recursion.js
+++ b/lib/compiler/passes/report-left-recursion.js
@@ -11,7 +11,9 @@ function reportLeftRecursion(ast) {
     },
 
     sequence: function(node, appliedRules) {
-      check(node.elements[0], appliedRules);
+      if (node.elements.length > 0) {
+        check(node.elements[0], appliedRules);
+      }
     },
 
     rule_ref: function(node, appliedRules) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -69,9 +69,11 @@ module.exports = (function() {
                 : expression;
             },
         peg$c9 = function(first, rest) {
-              return rest.length > 0
-                ? { type: "sequence", elements: buildList(first, rest, 1) }
-                : first;
+              return first === null
+                ? { type: "sequence", elements: [] }
+                : rest.length > 0
+                  ? { type: "sequence", elements: buildList(first, rest, 1) }
+                  : first;
             },
         peg$c10 = ":",
         peg$c11 = { type: "literal", value: ":", description: "\":\"" },
@@ -819,6 +821,9 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       s1 = peg$parseLabeledExpression();
+      if (s1 === peg$FAILED) {
+        s1 = null;
+      }
       if (s1 !== peg$FAILED) {
         s2 = [];
         s3 = peg$currPos;

--- a/spec/api/generated-parser-behavior.spec.js
+++ b/spec/api/generated-parser-behavior.spec.js
@@ -359,7 +359,13 @@ describe("generated parser behavior", function() {
     });
 
     describe("sequence matching", function() {
-      it("matches correctly", function() {
+      it("matches empty sequence correctly", function() {
+        var parser = PEG.buildParser('start = ', options);
+
+        expect(parser).toParse("", []);
+      });
+
+      it("matches non-empty sequence correctly", function() {
         var parser = PEG.buildParser('start = "a" "b" "c"', options);
 
         expect(parser).toParse("abc", ["a", "b", "c"]);
@@ -823,9 +829,9 @@ describe("generated parser behavior", function() {
 
       describe("expectations reporting", function() {
         it("reports expectations correctly with no alternative", function() {
-          var parser = PEG.buildParser('start = "a"', options);
+          var parser = PEG.buildParser('start = ', options);
 
-          expect(parser).toFailToParse("ab", {
+          expect(parser).toFailToParse("a", {
             expected: [{ type: "end", description: "end of input" }]
           });
         });
@@ -894,10 +900,10 @@ describe("generated parser behavior", function() {
 
       describe("message building", function() {
         it("builds message correctly with no alternative", function() {
-          var parser = PEG.buildParser('start = "a"', options);
+          var parser = PEG.buildParser('start = ', options);
 
-          expect(parser).toFailToParse("ab", {
-            message: 'Expected end of input but "b" found.'
+          expect(parser).toFailToParse("a", {
+            message: 'Expected end of input but "a" found.'
           });
         });
 

--- a/spec/unit/compiler/passes/generate-bytecode.spec.js
+++ b/spec/unit/compiler/passes/generate-bytecode.spec.js
@@ -86,23 +86,21 @@ describe("compiler pass |generateBytecode|", function() {
 
   describe("for action", function() {
     describe("without labels", function() {
-      var grammar = 'start = "a" { code }';
+      var grammar = 'start = { code }';
 
       it("generates correct bytecode", function() {
         expect(pass).toChangeAST(grammar, bytecodeDetails([
           1,                           // PUSH_CURR_POS
-          14, 0, 2, 2, 18, 0, 19, 1,   // <expression>
+          29,                          // <expression>
           11, 6, 0,                    // IF_NOT_ERROR
           20, 1,                       //   * REPORT_SAVED_POS
-          22, 2, 1, 0,                 //     CALL
+          22, 0, 1, 0,                 //     CALL <0>
           5                            // NIP
         ]));
       });
 
       it("defines correct constants", function() {
         expect(pass).toChangeAST(grammar, constsDetails([
-          '"a"',
-          '{ type: "literal", value: "a", description: "\\"a\\"" }',
           'function() { code }'
         ]));
       });
@@ -173,40 +171,56 @@ describe("compiler pass |generateBytecode|", function() {
   });
 
   describe("for sequence", function() {
-    var grammar = 'start = "a" "b" "c"';
+    describe("empty", function() {
+      var grammar = 'start = ';
 
-    it("generates correct bytecode", function() {
-      expect(pass).toChangeAST(grammar, bytecodeDetails([
-        1,                           // PUSH_CURR_POS
-        14, 0, 2, 2, 18, 0, 19, 1,   // <elements[0]>
-        11, 33, 3,                   // IF_NOT_ERROR
-        14, 2, 2, 2, 18, 2, 19, 3,   //   * <elements[1]>
-        11, 18, 4,                   //     IF_NOT_ERROR
-        14, 4, 2, 2, 18, 4, 19, 5,   //       * <elements[2]>
-        11, 3, 4,                    //         IF_NOT_ERROR
-        7, 3,                        //           * WRAP
-        5,                           //             NIP
-        4, 3,                        //           * POP_N
-        3,                           //             POP_CURR_POS
-        28,                          //             PUSH_FAILED
-        4, 2,                        //       * POP_N
-        3,                           //         POP_CURR_POS
-        28,                          //         PUSH_FAILED
-        2,                           //   * POP
-        3,                           //     POP_CURR_POS
-        28                           //     PUSH_FAILED
-      ]));
+      it("generates correct bytecode", function() {
+        expect(pass).toChangeAST(grammar, bytecodeDetails([
+          29     // PUSH_EMPTY_ARRAY
+        ]));
+      });
+
+      it("defines correct constants", function() {
+        expect(pass).toChangeAST(grammar, constsDetails([]));
+      });
     });
 
-    it("defines correct constants", function() {
-      expect(pass).toChangeAST(grammar, constsDetails([
-        '"a"',
-        '{ type: "literal", value: "a", description: "\\"a\\"" }',
-        '"b"',
-        '{ type: "literal", value: "b", description: "\\"b\\"" }',
-        '"c"',
-        '{ type: "literal", value: "c", description: "\\"c\\"" }'
-      ]));
+    describe("non-empty", function() {
+      var grammar = 'start = "a" "b" "c"';
+
+      it("generates correct bytecode", function() {
+        expect(pass).toChangeAST(grammar, bytecodeDetails([
+          1,                           // PUSH_CURR_POS
+          14, 0, 2, 2, 18, 0, 19, 1,   // <elements[0]>
+          11, 33, 3,                   // IF_NOT_ERROR
+          14, 2, 2, 2, 18, 2, 19, 3,   //   * <elements[1]>
+          11, 18, 4,                   //     IF_NOT_ERROR
+          14, 4, 2, 2, 18, 4, 19, 5,   //       * <elements[2]>
+          11, 3, 4,                    //         IF_NOT_ERROR
+          7, 3,                        //           * WRAP
+          5,                           //             NIP
+          4, 3,                        //           * POP_N
+          3,                           //             POP_CURR_POS
+          28,                          //             PUSH_FAILED
+          4, 2,                        //       * POP_N
+          3,                           //         POP_CURR_POS
+          28,                          //         PUSH_FAILED
+          2,                           //   * POP
+          3,                           //     POP_CURR_POS
+          28                           //     PUSH_FAILED
+        ]));
+      });
+
+      it("defines correct constants", function() {
+        expect(pass).toChangeAST(grammar, constsDetails([
+          '"a"',
+          '{ type: "literal", value: "a", description: "\\"a\\"" }',
+          '"b"',
+          '{ type: "literal", value: "b", description: "\\"b\\"" }',
+          '"c"',
+          '{ type: "literal", value: "c", description: "\\"c\\"" }'
+        ]));
+      });
     });
   });
 

--- a/spec/unit/parser.spec.js
+++ b/spec/unit/parser.spec.js
@@ -21,6 +21,10 @@ describe("PEG.js grammar parser", function() {
         type:     "sequence",
         elements: [literalAbcd, literalEfgh, literalIjkl]
       },
+      sequence0         = {
+        type:     "sequence",
+        elements: []
+      },
       sequence2         = {
         type:     "sequence",
         elements: [labeledAbcd, labeledEfgh]
@@ -241,6 +245,9 @@ describe("PEG.js grammar parser", function() {
 
   /* Canonical SequenceExpression is "\"abcd\" \"efgh\" \"ijkl\"". */
   it("parses SequenceExpression", function() {
+    expect('start = ').toParseAs(
+      oneRuleGrammar(sequence0)
+    );
     expect('start = a:"abcd"').toParseAs(
       oneRuleGrammar(labeledAbcd)
     );

--- a/src/parser.pegjs
+++ b/src/parser.pegjs
@@ -123,10 +123,12 @@ ActionExpression
     }
 
 SequenceExpression
-  = first:LabeledExpression rest:(__ LabeledExpression)* {
-      return rest.length > 0
-        ? { type: "sequence", elements: buildList(first, rest, 1) }
-        : first;
+  = first:LabeledExpression? rest:(__ LabeledExpression)* {
+      return first === null
+        ? { type: "sequence", elements: [] }
+        : rest.length > 0
+          ? { type: "sequence", elements: buildList(first, rest, 1) }
+          : first;
     }
 
 LabeledExpression


### PR DESCRIPTION
This reverts commit df154daafb9c6c952351493af02d3a55e0b05c59.

Conflicts:
	lib/compiler/passes/generate-bytecode.js
	lib/parser.js
	spec/parser.spec.js
	spec/unit/compiler/passes/generate-bytecode.spec.js
	src/parser.pegjs

I think, change from df154daafb9c6c952351493af02d3a55e0b05c59 creates more problems, than decides. For example, I have a grammar describing the protocol of the ATM which looks approximately so (I use Ranges extension from #267):
```
GS 'Group Separator' = '\x1D' {return '<GS>'};
n4 'n4' = n:$[0-9]| 4| {return parseInt(n,10);};
n5 'n5' = n:$[0-9]| 5| {return parseInt(n,10);};
n7 'n7' = n:$[0-9]| 7| {return parseInt(n,10);};

TerminalState 'Terminal State'
  = '1' ConfigInfo                   // Send configuration information
//...
  / '7' ExtendedSupplyCounter|.., GS|// Send supply counters (extended)
//...
  ;
ConfigInfo = ...;
ExtendedSupplyCounter
  = 'A' tsn:n4 tranCnt:n7 // Transaction
  / 'B' cardsCaptured:n5  // Card Reader
//...
// Though all fields are marked with the identifier, however documentation
// says that they will go in strictly certain order (as it is specified here) and
// if any data aren't, there will be GS
  /  // <-- Problem. What here shall be?
  ;
```
The grammar shall accept such sequence (field `B` is omitted, but GS for this still present) but after this commit it is impossible:
```
...7A...<GS><GS>C...<GS>D...
```
I suggest to rollback it since it creates unnecessary complication of a parser and isn't obvious at all.