### PR TITLE
Allow multiply output types and add new output type "ast".

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -30,6 +30,13 @@ var compiler = {
    * cause its malfunction.
    */
   compile: function(ast, passes) {
+    function mapOutput(kind) {
+      switch (kind) {
+        case "parser": return eval(ast.code);
+        case "source": return ast.code;
+        case "ast"   : return ast;
+      }
+    }
     var options = arguments.length > 2 ? objects.clone(arguments[2]) : {},
         stage;
 
@@ -46,9 +53,10 @@ var compiler = {
       }
     }
 
-    switch (options.output) {
-      case "parser": return eval(ast.code);
-      case "source": return ast.code;
+    if (arrays.isArray(options.output)) {
+      return arrays.createObject(options.output, mapOutput);
+    } else {
+      return mapOutput(options.output);
     }
   }
 };

--- a/lib/utils/arrays.js
+++ b/lib/utils/arrays.js
@@ -1,5 +1,9 @@
 /* Array utilities. */
 var arrays = {
+  isArray: function(object) {
+    return Object.prototype.toString.apply(object) === "[object Array]";
+  },
+
   range: function(start, stop) {
     var length = stop - start,
         result = new Array(length),
@@ -76,6 +80,18 @@ var arrays = {
 
   pluck: function(array, key) {
     return arrays.map(array, function (e) { return e[key]; });
+  },
+
+  createObject: function(keys, iterator) {
+    var length = keys.length,
+        result = {},
+        i;
+
+    for (i = 0; i < length; i++) {
+      result[keys[i]] = iterator(keys[i], i);
+    }
+
+    return result;
   }
 };
 


### PR DESCRIPTION
Now `options.output` may be an array of supported output types. Output types is:
- `parser`
- `source`
- `ast` (new)

If output types are an array, `buildParser` returns object whose keys are array elements, and values -- the appropriate results of generation.