### PR TITLE
Bullet-proof report left recursion

### DIFF
--- a/lib/compiler/passes/report-left-recursion.js
+++ b/lib/compiler/passes/report-left-recursion.js
@@ -5,13 +5,12 @@ var arrays       = require("../../utils/arrays"),
 
 /* Checks that no left recursion is present. */
 function reportLeftRecursion(ast) {
-  // Each visitor function returns minimum number of AST nodes, that it must consume.
-  // If this number == 0, than left recursion is possible
-  function return0() { return 0; };
-  function return1() { return 1; };
-  function visitExpressionAndReturn0(node, pos, appliedRules) {
-    check(node.expression, pos, appliedRules);
-    return 0;
+  // Each visitor function returns |true|, if some input wiil be consumed in any case,
+  // and |false| otherwize. In last case left recursion is possible.
+  function returnFalse() { return false; };
+  function visitExpressionAndReturnFalse(node, appliedRules) {
+    check(node.expression, appliedRules);
+    return false;
   };
 
   var detected = {};
@@ -21,11 +20,11 @@ function reportLeftRecursion(ast) {
       arrays.each(node.rules, function(rule) {
         // If rule already detected, not needed check it again
         if (!detected[rule.name]) {
-          check(rule, 0, []);
+          check(rule, []);
         }
       });
     },
-    rule: function(node, pos, appliedRules) {
+    rule: function(node, appliedRules) {
       // For initial call |appliedRules| is empty, so that not trigger
       var hasLeftRecursion = arrays.contains(appliedRules, node.name);
       appliedRules.push(node.name);
@@ -35,46 +34,47 @@ function reportLeftRecursion(ast) {
           // If you need multimply error detection in one pass, just not throw exception
           // there, but notify your backend.
           throw new GrammarError('Left recursion detected: ' + appliedRules.join('->'));
-          return 0;
+          return false;
         } else {
-          return check(node.expression, pos, appliedRules);
+          return check(node.expression, appliedRules);
         }
       } finally {
         appliedRules.pop();
       }
     },
-    choice: function(node, pos, appliedRules) {
-      var min = pos;
+    choice: function(node, appliedRules) {
       for (var i = 0; i < node.alternatives.length; ++i) {
-        min = Math.min(min, check(node.alternatives[i], pos, appliedRules));
-      }
-      return min;
-    },
-    sequence: function(node, pos, appliedRules) {
-      var delta;
-      for (var i = 0; i < node.elements.length; ++i) {
-        delta = check(node.elements[i], pos, appliedRules);
-        pos += delta;
-        // Left recursion is inpossible, because we make at least one step forward
-        if (delta > 0) {
-          break;
+        // If all alternatives can not consume any input, than left recursion is possible.
+        if (!check(node.alternatives[i], appliedRules)) {
+          return false;
         }
       }
-      return pos;
+      // If all alternatives consume some input, than, if has any alternative,
+      // |choice| consume input.
+      return node.alternatives.length > 0;
     },
-    simple_and:   visitExpressionAndReturn0,
-    simple_not:   visitExpressionAndReturn0,
-    optional:     visitExpressionAndReturn0,
-    zero_or_more: visitExpressionAndReturn0,
-    semantic_and: return0,
-    semantic_not: return0,
-    rule_ref: function(node, pos, appliedRules) {
+    sequence: function(node, appliedRules) {
+      for (var i = 0; i < node.elements.length; ++i) {
+        // Left recursion is inpossible, because we make at least one step forward
+        if (check(node.elements[i], appliedRules)) {
+          return true;
+        }
+      }
+      return false;
+    },
+    simple_and:   visitExpressionAndReturnFalse,
+    simple_not:   visitExpressionAndReturnFalse,
+    optional:     visitExpressionAndReturnFalse,
+    zero_or_more: visitExpressionAndReturnFalse,
+    semantic_and: returnFalse,
+    semantic_not: returnFalse,
+    rule_ref: function(node, appliedRules) {
       var rule = asts.findRule(ast, node.name);
-      return rule ? check(rule, pos, appliedRules) : 0;
+      return rule ? check(rule, appliedRules) : false;
     },
-    literal: function(n) { return n.value.length; },
-    "class": function(n) { return n.parts.length; },
-    any:     function() { return 1; }
+    literal: function(n) { return n.value.length > 0; },
+    "class": function(n) { return n.parts.length > 0; },
+    any:     function()  { return true; }
   });
 
   check(ast);

--- a/lib/compiler/passes/report-left-recursion.js
+++ b/lib/compiler/passes/report-left-recursion.js
@@ -5,26 +5,79 @@ var arrays       = require("../../utils/arrays"),
 
 /* Checks that no left recursion is present. */
 function reportLeftRecursion(ast) {
+  // Each visitor function returns minimum number of AST nodes, that it must consume.
+  // If this number == 0, than left recursion is possible
+  function return0() { return 0; };
+  function return1() { return 1; };
+  function visitExpressionAndReturn0(node, pos, appliedRules) {
+    check(node.expression, pos, appliedRules);
+    return 0;
+  };
+
+  var detected = {};
+
   var check = visitor.build({
-    rule: function(node, appliedRules) {
-      check(node.expression, appliedRules.concat(node.name));
+    grammar: function(node) {
+      arrays.each(node.rules, function(rule) {
+        // If rule already detected, not needed check it again
+        if (!detected[rule.name]) {
+          check(rule, 0, []);
+        }
+      });
     },
-
-    sequence: function(node, appliedRules) {
-      check(node.elements[0], appliedRules);
-    },
-
-    rule_ref: function(node, appliedRules) {
-      if (arrays.contains(appliedRules, node.name)) {
-        throw new GrammarError(
-          "Left recursion detected for rule \"" + node.name + "\"."
-        );
+    rule: function(node, pos, appliedRules) {
+      // For initial call |appliedRules| is empty, so that not trigger
+      var hasLeftRecursion = arrays.contains(appliedRules, node.name);
+      appliedRules.push(node.name);
+      try {
+        if (hasLeftRecursion) {
+          arrays.each(appliedRules, function(name) { detected[name] = true; });
+          // If you need multimply error detection in one pass, just not throw exception
+          // there, but notify your backend.
+          throw new GrammarError('Left recursion detected: ' + appliedRules.join('->'));
+          return 0;
+        } else {
+          return check(node.expression, pos, appliedRules);
+        }
+      } finally {
+        appliedRules.pop();
       }
-      check(asts.findRule(ast, node.name), appliedRules);
-    }
+    },
+    choice: function(node, pos, appliedRules) {
+      var min = pos;
+      for (var i = 0; i < node.alternatives.length; ++i) {
+        min = Math.min(min, check(node.alternatives[i], pos, appliedRules));
+      }
+      return min;
+    },
+    sequence: function(node, pos, appliedRules) {
+      var delta;
+      for (var i = 0; i < node.elements.length; ++i) {
+        delta = check(node.elements[i], pos, appliedRules);
+        pos += delta;
+        // Left recursion is inpossible, because we make at least one step forward
+        if (delta > 0) {
+          break;
+        }
+      }
+      return pos;
+    },
+    simple_and:   visitExpressionAndReturn0,
+    simple_not:   visitExpressionAndReturn0,
+    optional:     visitExpressionAndReturn0,
+    zero_or_more: visitExpressionAndReturn0,
+    semantic_and: return0,
+    semantic_not: return0,
+    rule_ref: function(node, pos, appliedRules) {
+      var rule = asts.findRule(ast, node.name);
+      return rule ? check(rule, pos, appliedRules) : 0;
+    },
+    literal: function(n) { return n.value.length; },
+    "class": function(n) { return n.parts.length; },
+    any:     function() { return 1; }
   });
 
-  check(ast, []);
+  check(ast);
 }
 
 module.exports = reportLeftRecursion;

--- a/lib/compiler/passes/report-left-recursion.js
+++ b/lib/compiler/passes/report-left-recursion.js
@@ -70,7 +70,8 @@ function reportLeftRecursion(ast) {
     semantic_not: returnFalse,
     rule_ref: function(node, appliedRules) {
       var rule = asts.findRule(ast, node.name);
-      return rule ? check(rule, appliedRules) : false;
+      // If rule not exist, not trigger left recursion, because we don't know it.
+      return rule ? check(rule, appliedRules) : true;
     },
     literal: function(n) { return n.value.length > 0; },
     "class": function(n) { return n.parts.length > 0; },

--- a/lib/compiler/visitor.js
+++ b/lib/compiler/visitor.js
@@ -13,7 +13,7 @@ var visitor = {
     function visitExpression(node) {
       var extraArgs = Array.prototype.slice.call(arguments, 1);
 
-      visit.apply(null, [node.expression].concat(extraArgs));
+      return visit.apply(null, [node.expression].concat(extraArgs));
     }
 
     function visitChildren(property) {

--- a/spec/unit/compiler/passes/helpers.js
+++ b/spec/unit/compiler/passes/helpers.js
@@ -80,6 +80,7 @@ beforeEach(function() {
         if (this.isNot) {
           this.message = function() {
             return "Expected the pass not to report an error"
+                 + (details ? " with details " + jasmine.pp(details) : "") + ", "
                  + "for grammar " + jasmine.pp(grammar) + ", "
                  + "but it did.";
           };

--- a/spec/unit/compiler/passes/report-left-recursion.spec.js
+++ b/spec/unit/compiler/passes/report-left-recursion.spec.js
@@ -43,6 +43,25 @@ describe("compiler pass |reportLeftRecursion|", function() {
     }
   });
 
+  it("not reports left recursion, if some rules in possible recursion path not exist", function() {
+    var tests = [
+      'start = nonexist start;',
+      'start = nonexist start "a";',
+      'start = nonexist start {};',
+      'start = nonexist "a"? start;',
+      'start = nonexist "a"* start;',
+      'start = nonexist !"a" start;',
+      'start = nonexist &"a" start;',
+      'start = nonexist !{} start;',
+      'start = nonexist &{} start;',
+      'start = nonexist "" start;',
+      'start = nonexist [] start;'
+    ];
+    for (var i = 0; i < tests.length; ++i) {
+      expect(pass).not.toReportError(tests[i]);
+    }
+  });
+
   describe("in sequences", function() {
     it("not report left recursion when preceding elements consume input", function() {
       var tests = [

--- a/spec/unit/compiler/passes/report-left-recursion.spec.js
+++ b/spec/unit/compiler/passes/report-left-recursion.spec.js
@@ -2,28 +2,56 @@ describe("compiler pass |reportLeftRecursion|", function() {
   var pass = PEG.compiler.passes.check.reportLeftRecursion;
 
   it("reports direct left recursion", function() {
-    expect(pass).toReportError('start = start', {
-      message: 'Left recursion detected for rule \"start\".'
-    });
+    var tests = [
+      'start = start;',
+      'start = start {};',
+      'start = "a"? start;',
+      'start = "a"* start;',
+      'start = !"a" start;',
+      'start = &"a" start;',
+      'start = !{} start;',
+      'start = &{} start;',
+      'start = "" start;',
+      'start = [] start;'
+    ];
+    for (var i = 0; i < tests.length; ++i) {
+      expect(pass).toReportError(tests[i], {
+        message: 'Left recursion detected: start->start'
+      });
+    }
   });
 
   it("reports indirect left recursion", function() {
-    expect(pass).toReportError([
-      'start = stop',
-      'stop  = start'
-    ].join("\n"), {
-      message: 'Left recursion detected for rule \"start\".'
-    });
+    var tests = [
+      'start = stop; stop = start;',
+      'start = stop; stop = start {};',
+      'start = stop; stop = "a"? start;',
+      'start = stop; stop = "a"* start;',
+      'start = stop; stop = !"a" start;',
+      'start = stop; stop = &"a" start;',
+      'start = stop; stop = !{} start;',
+      'start = stop; stop = &{} start;',
+      'start = stop; stop = "" start;',
+      'start = stop; stop = [] start;'
+    ];
+    for (var i = 0; i < tests.length; ++i) {
+      expect(pass).toReportError(tests[i], {
+        message: 'Left recursion detected: start->stop->start'
+      });
+    }
+  });
+  it("not report reports indirect left recursion", function() {
   });
 
   describe("in sequences", function() {
     it("reports left recursion only for the first element", function() {
       expect(pass).toReportError('start = start "a" "b"', {
-        message: 'Left recursion detected for rule \"start\".'
+        message: 'Left recursion detected: start->start'
       });
 
       expect(pass).not.toReportError('start = "a" start "b"');
       expect(pass).not.toReportError('start = "a" "b" start');
+      expect(pass).not.toReportError('start = "a"+ start');
     });
   });
 });


### PR DESCRIPTION
How it works: main idea in what for `sequence` it is insufficiently simple to check the first element of sequence because exist cases described in #190, that also have left recursion. Grammars
```
S = a? S
S = a* S
```
it is possible to present in the equivalent form
```
S = S / a S
S = S / a + S
```
As you see, that is classical left recursion. In general, any production, which doesn't consume an input, can lead to the left recursion.

Therefore, if we walk through AST of the rule and we will consume the smallest theoretically possible input, we will be able to define, whether it can lead to the left recursion. We need check all `sequence` elements while one not consume some input. After that any left recursion is inpossible. So, main advantages in checking not only first element of `sequence` node, but all, while some input won't be consumed.