### PR TITLE
fix generated parsers not working in strict mode

### DIFF
--- a/lib/compiler/passes/generate-javascript.js
+++ b/lib/compiler/passes/generate-javascript.js
@@ -965,7 +965,7 @@ function generateJavascript(ast, options) {
   }
 
   if (ast.initializer) {
-    parts.push(indent4("{" + ast.initializer.code + "}"));
+    parts.push(indent2(ast.initializer.code));
     parts.push('');
   }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -4835,54 +4835,54 @@ module.exports = (function() {
       return s0;
     }
 
-    {
-      var OPS_TO_PREFIXED_TYPES = {
-        "$": "text",
-        "&": "simple_and",
-        "!": "simple_not"
-      };
 
-      var OPS_TO_SUFFIXED_TYPES = {
-        "?": "optional",
-        "*": "zero_or_more",
-        "+": "one_or_more"
-      };
+    var OPS_TO_PREFIXED_TYPES = {
+      "$": "text",
+      "&": "simple_and",
+      "!": "simple_not"
+    };
 
-      var OPS_TO_SEMANTIC_PREDICATE_TYPES = {
-        "&": "semantic_and",
-        "!": "semantic_not"
-      };
+    var OPS_TO_SUFFIXED_TYPES = {
+      "?": "optional",
+      "*": "zero_or_more",
+      "+": "one_or_more"
+    };
 
-      function filterEmptyStrings(array) {
-        var result = [], i;
+    var OPS_TO_SEMANTIC_PREDICATE_TYPES = {
+      "&": "semantic_and",
+      "!": "semantic_not"
+    };
 
-        for (i = 0; i < array.length; i++) {
-          if (array[i] !== "") {
-            result.push(array[i]);
-          }
+    function filterEmptyStrings(array) {
+      var result = [], i;
+
+      for (i = 0; i < array.length; i++) {
+        if (array[i] !== "") {
+          result.push(array[i]);
         }
-
-        return result;
       }
 
-      function extractOptional(optional, index) {
-        return optional ? optional[index] : null;
-      }
-
-      function extractList(list, index) {
-        var result = new Array(list.length), i;
-
-        for (i = 0; i < list.length; i++) {
-          result[i] = list[i][index];
-        }
-
-        return result;
-      }
-
-      function buildList(first, rest, index) {
-        return [first].concat(extractList(rest, index));
-      }
+      return result;
     }
+
+    function extractOptional(optional, index) {
+      return optional ? optional[index] : null;
+    }
+
+    function extractList(list, index) {
+      var result = new Array(list.length), i;
+
+      for (i = 0; i < list.length; i++) {
+        result[i] = list[i][index];
+      }
+
+      return result;
+    }
+
+    function buildList(first, rest, index) {
+      return [first].concat(extractList(rest, index));
+    }
+
 
     peg$result = peg$startRuleFunction();
 


### PR DESCRIPTION
I had written a PEG that was working in the online demo but not in my app. There were two problems.

The first error I got was `generate-bytecode.js:406 Uncaught ReferenceError: failedIndex is not defined`.

Took me a while to figure out what was going on, because there's no such symbol `failedIndex` in either the latest commit to master or the 0.8.0 tagged commit.

I had installed pegjs with `npm install --save-dev pegjs`, which reports the version as 0.8.0. However, the `failedIndex` error goes away if I install pegjs with `npm install --save-dev pegjs/pegjs`, which is also version 0.8.0. No idea where npm got the broken version of 0.8.0, maybe it has something to do with the repository being moved from one namespace to another on github. As you can see here https://www.npmjs.com/package/pegjs npm still lists the package source as github.com/dmajda/pegjs.

Anyway, with `pegjs/pegjs` the `failedIndex` error is gone, but then I have the problem fixed in this pull request: `parser.js:4838 Uncaught SyntaxError: Unexpected strict mode reserved word`

So what's happening here is the javascript generator wraps the parser initializer in `{` `}`. This is invalid javascript code; it looks like a bare object but contains a block of code rather than object members.

The generated parsers don't include a `'use strict';` statement, so this normally just works anyway I guess. But I'm using webpack which is bundling a generated parser together with other modules and apparently strict mode is somehow applying to the parser, which causes the browser to bail out instead of executing the contents of the `{` `}` block.

My patch just stops wrapping the initializer in `{` `}`. It appears to work, but I'm wondering if the initializer and other code blocks should actually be more isolated from the rest of the generated code. I see most of the items defined inside `function peg$parse` are prefixed with `peg$` to prevent collisions, but there are a few names that a user might try to use: `input`, `options`, `text`, `offset`, `line`, `column`, `expected`, `error`. In fact, if I make an initializer like `{ input = null; }`, the parser breaks.