### PR TITLE
Disallowed duplicate rule and label names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,22 @@ PEGJS_VERSION = `cat $(VERSION_FILE)`
 # ===== Modules =====
 
 # Order matters -- dependencies must be listed before modules dependent on them.
-MODULES = utils/arrays                          \
-          utils/objects                         \
-          utils/classes                         \
-          grammar-error                         \
-          parser                                \
-          compiler/asts                         \
-          compiler/visitor                      \
-          compiler/opcodes                      \
-          compiler/javascript                   \
-          compiler/passes/generate-bytecode     \
-          compiler/passes/generate-javascript   \
-          compiler/passes/remove-proxy-rules    \
-          compiler/passes/report-left-recursion \
-          compiler/passes/report-missing-rules  \
-          compiler                              \
+MODULES = utils/arrays                            \
+          utils/objects                           \
+          utils/classes                           \
+          grammar-error                           \
+          parser                                  \
+          compiler/asts                           \
+          compiler/visitor                        \
+          compiler/opcodes                        \
+          compiler/javascript                     \
+          compiler/passes/generate-bytecode       \
+          compiler/passes/generate-javascript     \
+          compiler/passes/remove-proxy-rules      \
+          compiler/passes/report-duplicate-labels \
+          compiler/passes/report-left-recursion   \
+          compiler/passes/report-missing-rules    \
+          compiler                                \
           peg
 
 # ===== Directories =====

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ MODULES = utils/arrays                            \
           compiler/passes/remove-proxy-rules      \
           compiler/passes/report-duplicate-labels \
           compiler/passes/report-left-recursion   \
+          compiler/passes/report-duplicate-rules  \
           compiler/passes/report-missing-rules    \
           compiler                                \
           peg

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -12,6 +12,7 @@ var compiler = {
   passes: {
     check: {
       reportMissingRules:    require("./compiler/passes/report-missing-rules"),
+      reportDuplicateRules:  require("./compiler/passes/report-duplicate-rules"),
       reportLeftRecursion:   require("./compiler/passes/report-left-recursion"),
       reportDuplicateLabels: require("./compiler/passes/report-duplicate-labels")
     },
@@ -39,6 +40,7 @@ var compiler = {
       cache:                 false,
       optimize:              "speed",
       output:                "parser",
+      reportDuplicateRules:  true,
       reportDuplicateLabels: true
     });
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -11,15 +11,16 @@ var compiler = {
    */
   passes: {
     check: {
-      reportMissingRules:  require("./compiler/passes/report-missing-rules"),
-      reportLeftRecursion: require("./compiler/passes/report-left-recursion")
+      reportMissingRules:    require("./compiler/passes/report-missing-rules"),
+      reportLeftRecursion:   require("./compiler/passes/report-left-recursion"),
+      reportDuplicateLabels: require("./compiler/passes/report-duplicate-labels")
     },
     transform: {
-      removeProxyRules:    require("./compiler/passes/remove-proxy-rules")
+      removeProxyRules:      require("./compiler/passes/remove-proxy-rules")
     },
     generate: {
-      generateBytecode:    require("./compiler/passes/generate-bytecode"),
-      generateJavascript:  require("./compiler/passes/generate-javascript")
+      generateBytecode:      require("./compiler/passes/generate-bytecode"),
+      generateJavascript:    require("./compiler/passes/generate-javascript")
     }
   },
 
@@ -34,10 +35,11 @@ var compiler = {
         stage;
 
     objects.defaults(options, {
-      allowedStartRules:  [ast.rules[0].name],
-      cache:              false,
-      optimize:           "speed",
-      output:             "parser"
+      allowedStartRules:     [ast.rules[0].name],
+      cache:                 false,
+      optimize:              "speed",
+      output:                "parser",
+      reportDuplicateLabels: true
     });
 
     for (stage in passes) {

--- a/lib/compiler/passes/report-duplicate-labels.js
+++ b/lib/compiler/passes/report-duplicate-labels.js
@@ -1,0 +1,37 @@
+var GrammarError = require("../../grammar-error"),
+    visitor      = require("../visitor"),
+    arrays       = require("../../utils/arrays");
+
+/* Checks that there are no duplicate labels within a rule. */
+function reportDuplicateLabels(ast, options) {
+  if ( options && options.reportDuplicateLabels == true ) {
+    var check = visitor.build({
+      rule: function(node) {
+        check(node.expression, node.name, {});
+      },
+  
+      choice: function(node, ruleName) {
+        arrays.each(node.alternatives, function(child) {
+          check(child, ruleName, {});
+        });
+      },
+  
+      labeled: function(node, ruleName, labels) {
+        var labelName = node.label;
+        
+        if ( labels[labelName] ) {
+          throw new GrammarError(
+            'Duplicate label "' + labelName + '" detected for rule "' + ruleName + '". ' +
+            'To disable this error, simply set the option "reportDuplicateLabels" to "false" or "0".'
+          );
+        }
+  
+        labels[labelName] = true;
+      }
+    });
+  
+    check(ast);
+  }
+}
+
+module.exports = reportDuplicateLabels;

--- a/lib/compiler/passes/report-duplicate-rules.js
+++ b/lib/compiler/passes/report-duplicate-rules.js
@@ -1,0 +1,28 @@
+var GrammarError = require("../../grammar-error"),
+    visitor      = require("../visitor");
+
+/* Checks that there are no duplicate rules within the grammer. */
+function reportDuplicateRules(ast, options) {
+  if ( options && options.reportDuplicateRules == true ) {
+    var rules = {};
+    
+    var check = visitor.build({
+      rule: function(node) {
+        var ruleName = node.name;
+        
+        if ( rules[ruleName] ) {
+          throw new GrammarError(
+            'Duplicate rule "' + ruleName + '" detected in grammer. ' +
+            'To disable this error, simply set the option "reportDuplicateRules" to "false" or "0".'
+          );
+        }
+  
+        rules[ruleName] = true;
+      }
+    });
+  
+    check(ast);
+  }
+}
+
+module.exports = reportDuplicateRules;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lib/compiler/passes/generate-bytecode.js",
     "lib/compiler/passes/generate-javascript.js",
     "lib/compiler/passes/remove-proxy-rules.js",
+    "lib/compiler/passes/report-duplicate-labels.js",
     "lib/compiler/passes/report-left-recursion.js",
     "lib/compiler/passes/report-missing-rules.js",
     "lib/grammar-error.js",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lib/compiler/passes/remove-proxy-rules.js",
     "lib/compiler/passes/report-duplicate-labels.js",
     "lib/compiler/passes/report-left-recursion.js",
+    "lib/compiler/passes/report-duplicate-rules.js",
     "lib/compiler/passes/report-missing-rules.js",
     "lib/grammar-error.js",
     "lib/parser.js",

--- a/spec/index.html
+++ b/spec/index.html
@@ -10,6 +10,7 @@
     <script src="unit/parser.spec.js"></script>
     <script src="unit/compiler/passes/helpers.js"></script>
     <script src="unit/compiler/passes/report-missing-rules.spec.js"></script>
+    <script src="unit/compiler/passes/report-duplicate-rules.spec.js"></script>
     <script src="unit/compiler/passes/report-left-recursion.spec.js"></script>
     <script src="unit/compiler/passes/report-duplicate-labels.spec.js"></script>
     <script src="unit/compiler/passes/remove-proxy-rules.spec.js"></script>

--- a/spec/index.html
+++ b/spec/index.html
@@ -11,6 +11,7 @@
     <script src="unit/compiler/passes/helpers.js"></script>
     <script src="unit/compiler/passes/report-missing-rules.spec.js"></script>
     <script src="unit/compiler/passes/report-left-recursion.spec.js"></script>
+    <script src="unit/compiler/passes/report-duplicate-labels.spec.js"></script>
     <script src="unit/compiler/passes/remove-proxy-rules.spec.js"></script>
     <script src="unit/compiler/passes/generate-bytecode.spec.js"></script>
     <script src="api/pegjs-api.spec.js"></script>

--- a/spec/unit/compiler/passes/report-duplicate-labels.spec.js
+++ b/spec/unit/compiler/passes/report-duplicate-labels.spec.js
@@ -1,0 +1,28 @@
+describe("compiler pass |reportDuplicateLabels|", function() {
+  var pass = function ( ast ) {
+    return PEG.compiler.passes.check.reportDuplicateLabels(ast, { reportDuplicateLabels: true });
+  };
+  var details = { message:
+    'Duplicate label "a" detected for rule "start". ' +
+    'To disable this error, simply set the option "reportDuplicateLabels" to "false" or "0".'
+  };
+
+  it("reports duplicate labels", function(){
+    expect(pass).toReportError("start = a:'some' a:'thing'", details);
+  });
+
+  it("reports duplicate labels inside expressions", function(){
+    expect(pass).toReportError("start = (a:'some')* a:'thing'", details);
+  });
+
+  it("allows unique labels", function(){
+    expect(pass).not.toReportError("start = a:'some' b:'thing'");
+  });
+
+  it("allows identical labels on different rules", function(){
+    expect(pass).not.toReportError([
+      "start = a:'some' thing",
+      "thing = a:'thing'"
+    ].join('\n'));
+  });
+});

--- a/spec/unit/compiler/passes/report-duplicate-rules.spec.js
+++ b/spec/unit/compiler/passes/report-duplicate-rules.spec.js
@@ -1,0 +1,16 @@
+describe("compiler pass |reportDuplicateRules|", function() {
+  var pass = function ( ast ) {
+    return PEG.compiler.passes.check.reportDuplicateRules(ast, { reportDuplicateRules: true });
+  };
+  var details = { message:
+    'Duplicate rule "start" detected in grammer. ' +
+    'To disable this error, simply set the option "reportDuplicateRules" to "false" or "0".'
+  };
+
+  it("reports duplicate rules", function(){
+    expect(pass).toReportError([
+      "start = 'a'",
+      "start = 'a'"
+    ].join('\n'), details);
+  });
+});


### PR DESCRIPTION
This commit adds 2 pass's to the compiler that disallow:
- duplicate rule names (issue #318)
- duplicate label names (issue #270)

The duplicate labels pass is based on #278 (by @mulderr) but fixed, as the original was assuming all choices within a rule shared labels, which they don't. The spec test is updated as #316 removed the need for 2 checks within the *"reports duplicate labels inside expressions"* test. Also updated pass to allow the user to disable the check by setting the 'option.reportDuplicateLabels' to a false value ('false' or '0').