### PR TITLE
Add license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   ],
   "main":            "lib/peg",
   "bin":             "bin/pegjs",
+  "license":         "MIT",
   "scripts":         {
     "test": "make spec"
   },


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license