### PR TITLE
Use browserify for building the browser version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,27 +2,6 @@
 
 PEGJS_VERSION = `cat $(VERSION_FILE)`
 
-# ===== Modules =====
-
-# Order matters -- dependencies must be listed before modules dependent on them.
-MODULES = utils/arrays                          \
-          utils/objects                         \
-          utils/classes                         \
-          grammar-error                         \
-          parser                                \
-          compiler/visitor                      \
-          compiler/asts                         \
-          compiler/opcodes                      \
-          compiler/js                           \
-          compiler/passes/generate-bytecode     \
-          compiler/passes/generate-js           \
-          compiler/passes/remove-proxy-rules    \
-          compiler/passes/report-left-recursion \
-          compiler/passes/report-infinite-loops \
-          compiler/passes/report-missing-rules  \
-          compiler                              \
-          peg
-
 # ===== Directories =====
 
 SRC_DIR              = src
@@ -36,6 +15,8 @@ NODE_MODULES_BIN_DIR = $(NODE_MODULES_DIR)/.bin
 
 # ===== Files =====
 
+MAIN_FILE = $(LIB_DIR)/peg.js
+
 PARSER_SRC_FILE = $(SRC_DIR)/parser.pegjs
 PARSER_OUT_FILE = $(LIB_DIR)/parser.js
 
@@ -47,6 +28,7 @@ VERSION_FILE = VERSION
 # ===== Executables =====
 
 JSHINT        = $(NODE_MODULES_BIN_DIR)/jshint
+BROWSERIFY    = $(NODE_MODULES_BIN_DIR)/browserify
 UGLIFYJS      = $(NODE_MODULES_BIN_DIR)/uglifyjs
 JASMINE_NODE  = $(NODE_MODULES_BIN_DIR)/jasmine-node
 PEGJS         = $(BIN_DIR)/pegjs
@@ -78,41 +60,8 @@ browser:
 	echo ' * Copyright (c) 2010-2015 David Majda'                                      >> $(BROWSER_FILE_DEV)
 	echo ' * Licensed under the MIT license.'                                          >> $(BROWSER_FILE_DEV)
 	echo ' */'                                                                         >> $(BROWSER_FILE_DEV)
-	echo 'var PEG = (function(undefined) {'                                            >> $(BROWSER_FILE_DEV)
-	echo '  "use strict";'                                                             >> $(BROWSER_FILE_DEV)
-	echo ''                                                                            >> $(BROWSER_FILE_DEV)
-	echo '  var modules = {'                                                           >> $(BROWSER_FILE_DEV)
-	echo '    define: function(name, factory) {'                                       >> $(BROWSER_FILE_DEV)
-	echo '      var dir    = name.replace(/(^|\/)[^/]+$$/, "$$1"),'                    >> $(BROWSER_FILE_DEV)
-	echo '          module = { exports: {} };'                                         >> $(BROWSER_FILE_DEV)
-	echo ''                                                                            >> $(BROWSER_FILE_DEV)
-	echo '      function require(path) {'                                              >> $(BROWSER_FILE_DEV)
-	echo '        var name   = dir + path,'                                            >> $(BROWSER_FILE_DEV)
-	echo '            regexp = /[^\/]+\/\.\.\/|\.\//;'                                 >> $(BROWSER_FILE_DEV)
-	echo ''                                                                            >> $(BROWSER_FILE_DEV)
-	echo "        /* Can't use /.../g because we can move backwards in the string. */" >> $(BROWSER_FILE_DEV)
-	echo '        while (regexp.test(name)) {'                                         >> $(BROWSER_FILE_DEV)
-	echo '          name = name.replace(regexp, "");'                                  >> $(BROWSER_FILE_DEV)
-	echo '        }'                                                                   >> $(BROWSER_FILE_DEV)
-	echo ''                                                                            >> $(BROWSER_FILE_DEV)
-	echo '        return modules[name];'                                               >> $(BROWSER_FILE_DEV)
-	echo '      }'                                                                     >> $(BROWSER_FILE_DEV)
-	echo ''                                                                            >> $(BROWSER_FILE_DEV)
-	echo '      factory(module, require);'                                             >> $(BROWSER_FILE_DEV)
-	echo '      this[name] = module.exports;'                                          >> $(BROWSER_FILE_DEV)
-	echo '    }'                                                                       >> $(BROWSER_FILE_DEV)
-	echo '  };'                                                                        >> $(BROWSER_FILE_DEV)
-	echo ''                                                                            >> $(BROWSER_FILE_DEV)
 
-	for module in $(MODULES); do                                                                \
-	  echo "  modules.define(\"$$module\", function(module, require) {" >> $(BROWSER_FILE_DEV); \
-	  sed -e 's/^\(..*\)$$/    \1/' lib/$$module.js                     >> $(BROWSER_FILE_DEV); \
-	  echo '  });'                                                      >> $(BROWSER_FILE_DEV); \
-	  echo ''                                                           >> $(BROWSER_FILE_DEV); \
-	done
-
-	echo '  return modules["peg"]' >> $(BROWSER_FILE_DEV)
-	echo '})();'                   >> $(BROWSER_FILE_DEV)
+	$(BROWSERIFY) --standalone PEG $(MAIN_FILE) >> $(BROWSER_FILE_DEV)
 
 	$(UGLIFYJS)                 \
 	  --mangle                  \

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test": "make hint && make spec"
   },
   "devDependencies": {
+    "browserify":   "11.2.0",
     "jasmine-node": "1.14.5",
     "uglify-js":    "2.4.24",
     "jshint":       "2.8.0"


### PR DESCRIPTION
This resolves https://github.com/pegjs/pegjs/issues/373 and,
since `browserify` produces a UMD bundle (due to `--standalone PEG`),
addresses the first part of https://github.com/pegjs/pegjs/issues/362,

> 1. Making PEG.js itself UMD module.