### PR TITLE
Make generated parsers UMD modules using `umd` 3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,13 @@ file but with “.js” extension. You can also specify the output file explicit
 
 If you omit both input and output file, standard input and output are used.
 
-By default, the parser object is assigned to `module.exports`, which makes the
-output a Node.js module. You can assign it to another variable by passing a
-variable name using the `-e`/`--export-var` option. This may be helpful if you
-want to use the parser in browser environment.
+The output is a [UMD](https://github.com/ForbesLindesay/umd) module that
+exports the parser. If no module system is present, the parser object is
+assigned to `peg$parser` by default. You can assign it to another variable by
+passing a variable
+[name](https://github.com/ForbesLindesay/umd/tree/3.0.1#name-casing-and-characters)
+using the `-e`/`--export-var` option. This may be helpful if you want to use
+the parser in browser environment.
 
 You can tweak the generated parser with several options:
 

--- a/bin/pegjs
+++ b/bin/pegjs
@@ -4,7 +4,10 @@
 
 var fs   = require("fs");
 var path = require("path");
+var umd = require("umd");
 var PEG  = require("../lib/peg");
+
+var DEFAULT_EXPORT_VAR = "peg$parser";
 
 /* Helpers */
 
@@ -25,7 +28,7 @@ function printHelp() {
   console.log("Options:");
   console.log("  -e, --export-var <variable>        name of the variable where the parser");
   console.log("                                     object will be stored (default:");
-  console.log("                                     \"module.exports\")");
+  console.log("                                     \"" + DEFAULT_EXPORT_VAR + "\")");
   console.log("      --cache                        make generated parser cache results");
   console.log("      --allowed-start-rules <rules>  comma-separated list of rules the generated");
   console.log("                                     parser will be allowed to start parsing");
@@ -108,8 +111,8 @@ function readStream(inputStream, callback) {
 
 /* Main */
 
-/* This makes the generated parser a CommonJS module by default. */
-var exportVar = "module.exports";
+/* Try not to clobber any globals if no module system is present. */
+var exportVar = DEFAULT_EXPORT_VAR;
 var options = {
   cache:    false,
   output:   "source",
@@ -250,6 +253,7 @@ switch (args.length) {
 
 readStream(inputStream, function(input) {
   var source;
+  var umdSource;
 
   try {
     source = PEG.buildParser(input, options);
@@ -261,9 +265,9 @@ readStream(inputStream, function(input) {
     }
   }
 
-  outputStream.write(
-    exportVar !== "" ? exportVar + " = " + source + ";\n" : source + "\n"
-  );
+  umdSource = umd(exportVar, 'return ' + source);
+
+  outputStream.write(umdSource);
   if (outputStream !== process.stdout) {
     outputStream.end();
   }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
   "scripts":         {
     "test": "make hint && make spec"
   },
+  "dependencies": {
+    "umd": "3.0.1"
+  },
   "devDependencies": {
     "browserify":   "11.2.0",
     "jasmine-node": "1.14.5",


### PR DESCRIPTION
[`umd`][1] is what `browserify` uses (via [`browser-pack`][2]),
to generate UMD modules, so it seems appropriate to use here as well.

addresses #362

[1]: https://www.npmjs.com/package/umd
[2]: https://www.npmjs.com/package/browser-pack