### PR TITLE
travis: cache node_modules for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ node_js:
   - "0.10"
   - "0.12"
   - "iojs"
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
This reduces build times by around 10 seconds. ([example](https://travis-ci.org/joseph-onsip/pegjs/builds/86058074))

http://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies/