### PR TITLE
WIP: Use minimist to process CLI arguments

### DIFF
--- a/bin/pegjs
+++ b/bin/pegjs
@@ -4,6 +4,8 @@
 
 var fs   = require("fs");
 var path = require("path");
+var minimist = require("minimist");
+var arrays  = require("../lib/utils/arrays");
 var PEG  = require("../lib/peg");
 
 /* Helpers */
@@ -88,15 +90,10 @@ function trim(s) {
 
 /* Arguments */
 
-var args = process.argv.slice(2); // Trim "node" and the script path.
-
-function isOption(arg) {
-  return (/^-/).test(arg);
-}
-
-function nextArg() {
-  args.shift();
-}
+// Trim "node" and the script path.
+var argv = minimist(process.argv.slice(2), {
+  "boolean": ["cache", "trace"]
+});
 
 /* Files */
 
@@ -118,108 +115,77 @@ var options = {
   plugins:  []
 };
 
-while (args.length > 0 && isOption(args[0])) {
-  switch (args[0]) {
-    case "-e":
-    case "--export-var":
-      nextArg();
-      if (args.length === 0) {
-        abort("Missing parameter of the -e/--export-var option.");
-      }
-      exportVar = args[0];
-      break;
-
-    case "--cache":
-      options.cache = true;
-      break;
-
-    case "--allowed-start-rules":
-      nextArg();
-      if (args.length === 0) {
-        abort("Missing parameter of the --allowed-start-rules option.");
-      }
-      options.allowedStartRules = args[0]
-        .split(",")
-        .map(trim);
-      break;
-
-    case "--trace":
-      options.trace = true;
-      break;
-
-    case "-o":
-    case "--optimize":
-      nextArg();
-      if (args.length === 0) {
-        abort("Missing parameter of the -o/--optimize option.");
-      }
-      if (args[0] !== "speed" && args[0] !== "size") {
-        abort("Optimization goal must be either \"speed\" or \"size\".");
-      }
-      options.optimize = args[0];
-      break;
-
-    case "--plugin":
-      nextArg();
-      if (args.length === 0) {
-        abort("Missing parameter of the --plugin option.");
-      }
-      var id = /^(\.\/|\.\.\/)/.test(args[0]) ? path.resolve(args[0]) : args[0];
-      var mod;
-      try {
-        mod = require(id);
-      } catch (e) {
-        if (e.code !== "MODULE_NOT_FOUND") { throw e; }
-
-        abort("Can't load module \"" + id + "\".");
-      }
-      options.plugins.push(mod);
-      break;
-
-    case "--extra-options":
-      nextArg();
-      if (args.length === 0) {
-        abort("Missing parameter of the --extra-options option.");
-      }
-      addExtraOptions(options, args[0]);
-      break;
-
-    case "--extra-options-file":
-      nextArg();
-      if (args.length === 0) {
-        abort("Missing parameter of the --extra-options-file option.");
-      }
-      try {
-        var json = fs.readFileSync(args[0]);
-      } catch(e) {
-        abort("Can't read from file \"" + args[0] + "\".");
-      }
-      addExtraOptions(options, json);
-      break;
-
-    case "-v":
-    case "--version":
-      printVersion();
-      exitSuccess();
-      break;
-
-    case "-h":
-    case "--help":
-      printHelp();
-      exitSuccess();
-      break;
-
-    case "--":
-      nextArg();
-      break;
-
-    default:
-      abort("Unknown option: " + args[0] + ".");
-  }
-  nextArg();
+exportVar = argv.e || argv["export-var"];
+if (exportVar === true) {
+  abort("Missing parameter of the -e/--export-var option.");
 }
 
-switch (args.length) {
+options.cache = argv.cache;
+
+var allowedStartRules = argv["allowed-start-rules"];
+if (allowedStartRules === true) {
+  abort("Missing parameter of the --allowed-start-rules option.");
+}
+options.allowedStartRules = allowedStartRules
+  .split(",")
+  .map(trim);
+
+options.trace = argv.trace;
+
+var optimize = argv.o || argv.optimize;
+if (optimize === true) {
+  abort("Missing parameter of the -o/--optimize option.");
+}
+if (optimize !== "speed" && optimize !== "size") {
+  abort("Optimization goal must be either \"speed\" or \"size\".");
+}
+options.optimize = optimize;
+
+var plugins = [].concat(argv.plugin);
+arrays.each(plugins, function (plugin) {
+  if (plugin === true) {
+    abort("Missing parameter of the --plugin option.");
+  }
+  var id = /^(\.\/|\.\.\/)/.test(plugin) ? path.resolve(plugin) : plugin;
+  var mod;
+  try {
+    mod = require(id);
+  } catch (e) {
+    if (e.code !== "MODULE_NOT_FOUND") { throw e; }
+
+    abort("Can't load module \"" + id + "\".");
+  }
+  options.plugins.push(mod);
+});
+
+var extraOptions = argv["extra-options"];
+if (extraOptions === true) {
+  abort("Missing parameter of the --extra-options option.");
+}
+addExtraOptions(options, extraOptions);
+
+var extraOptionsFile = argv["extra-options-file"];
+if (extraOptionsFile === true) {
+  abort("Missing parameter of the --extra-options-file option.");
+}
+try {
+  var json = fs.readFileSync(extraOptionsFile);
+} catch(e) {
+  abort("Can't read from file \"" + extraOptionsFile + "\".");
+}
+addExtraOptions(options, json);
+
+if (argv.v || argv.version) {
+  printVersion();
+  exitSuccess();
+}
+
+if (argv.h || argv.help) {
+  printHelp();
+  exitSuccess();
+}
+
+switch (argv._.length) {
   case 0:
     process.stdin.resume();
     var inputStream = process.stdin;
@@ -228,15 +194,15 @@ switch (args.length) {
 
   case 1:
   case 2:
-    var inputFile = args[0];
+    var inputFile = argv._[0];
     var inputStream = fs.createReadStream(inputFile);
     inputStream.on("error", function() {
       abort("Can't read from file \"" + inputFile + "\".");
     });
 
-    var outputFile = args.length === 1
-      ? args[0].replace(/\.[^.]*$/, ".js")
-      : args[1];
+    var outputFile = argv._.length === 1
+      ? argv._[0].replace(/\.[^.]*$/, ".js")
+      : argv._[1];
     var outputStream = fs.createWriteStream(outputFile);
     outputStream.on("error", function() {
       abort("Can't write to file \"" + outputFile + "\".");

--- a/bin/pegjs
+++ b/bin/pegjs
@@ -205,18 +205,31 @@ switch (argv._.length) {
   case 1:
   case 2:
     var inputFile = argv._[0];
-    var inputStream = fs.createReadStream(inputFile);
-    inputStream.on("error", function() {
-      abort("Can't read from file \"" + inputFile + "\".");
-    });
+    if (inputFile === "-") {
+      process.stdin.resume();
+      var inputStream = process.stdin;
+      // We can't infer the output filename, so default to stdout if needed.
+      if (argv._.length === 1) {
+        argv._[1] = "-";
+      }
+    } else {
+      var inputStream = fs.createReadStream(inputFile);
+      inputStream.on("error", function() {
+        abort("Can't read from file \"" + inputFile + "\".");
+      });
+    }
 
     var outputFile = argv._.length === 1
       ? argv._[0].replace(/\.[^.]*$/, ".js")
       : argv._[1];
-    var outputStream = fs.createWriteStream(outputFile);
-    outputStream.on("error", function() {
-      abort("Can't write to file \"" + outputFile + "\".");
-    });
+    if (outputFile === "-") {
+      var outputStream = process.stdout;
+    } else {
+      var outputStream = fs.createWriteStream(outputFile);
+      outputStream.on("error", function() {
+        abort("Can't write to file \"" + outputFile + "\".");
+      });
+    }
 
     break;
 

--- a/bin/pegjs
+++ b/bin/pegjs
@@ -92,7 +92,13 @@ function trim(s) {
 
 // Trim "node" and the script path.
 var argv = minimist(process.argv.slice(2), {
-  "boolean": ["cache", "trace"]
+  "boolean": ["cache", "trace"],
+  "alias": {
+    e: "export-var",
+    o: "optimize",
+    v: "version",
+    h: "help"
+  }
 });
 
 /* Files */
@@ -115,33 +121,39 @@ var options = {
   plugins:  []
 };
 
-exportVar = argv.e || argv["export-var"];
-if (exportVar === true) {
-  abort("Missing parameter of the -e/--export-var option.");
+if (exportVar) {
+  if (exportVar === true) {
+    abort("Missing parameter of the -e/--export-var option.");
+  }
+  exportVar = argv["export-var"];
 }
 
 options.cache = argv.cache;
 
 var allowedStartRules = argv["allowed-start-rules"];
-if (allowedStartRules === true) {
-  abort("Missing parameter of the --allowed-start-rules option.");
+if (allowedStartRules) {
+  if (allowedStartRules === true) {
+    abort("Missing parameter of the --allowed-start-rules option.");
+  }
+  options.allowedStartRules = allowedStartRules
+    .split(",")
+    .map(trim);
 }
-options.allowedStartRules = allowedStartRules
-  .split(",")
-  .map(trim);
 
 options.trace = argv.trace;
 
-var optimize = argv.o || argv.optimize;
-if (optimize === true) {
-  abort("Missing parameter of the -o/--optimize option.");
+var optimize = argv.optimize;
+if (optimize) {
+  if (optimize === true) {
+    abort("Missing parameter of the -o/--optimize option.");
+  }
+  if (optimize !== "speed" && optimize !== "size") {
+    abort("Optimization goal must be either \"speed\" or \"size\".");
+  }
+  options.optimize = optimize;
 }
-if (optimize !== "speed" && optimize !== "size") {
-  abort("Optimization goal must be either \"speed\" or \"size\".");
-}
-options.optimize = optimize;
 
-var plugins = [].concat(argv.plugin);
+var plugins = [].concat(argv.plugin || []);
 arrays.each(plugins, function (plugin) {
   if (plugin === true) {
     abort("Missing parameter of the --plugin option.");
@@ -159,28 +171,32 @@ arrays.each(plugins, function (plugin) {
 });
 
 var extraOptions = argv["extra-options"];
-if (extraOptions === true) {
-  abort("Missing parameter of the --extra-options option.");
+if (extraOptions) {
+  if (extraOptions === true) {
+    abort("Missing parameter of the --extra-options option.");
+  }
+  addExtraOptions(options, extraOptions);
 }
-addExtraOptions(options, extraOptions);
 
 var extraOptionsFile = argv["extra-options-file"];
-if (extraOptionsFile === true) {
-  abort("Missing parameter of the --extra-options-file option.");
+if (extraOptionsFile) {
+  if (extraOptionsFile === true) {
+    abort("Missing parameter of the --extra-options-file option.");
+  }
+  try {
+    var json = fs.readFileSync(extraOptionsFile);
+  } catch(e) {
+    abort("Can't read from file \"" + extraOptionsFile + "\".");
+  }
+  addExtraOptions(options, json);
 }
-try {
-  var json = fs.readFileSync(extraOptionsFile);
-} catch(e) {
-  abort("Can't read from file \"" + extraOptionsFile + "\".");
-}
-addExtraOptions(options, json);
 
-if (argv.v || argv.version) {
+if (argv.version) {
   printVersion();
   exitSuccess();
 }
 
-if (argv.h || argv.help) {
+if (argv.help) {
   printHelp();
   exitSuccess();
 }

--- a/bin/pegjs
+++ b/bin/pegjs
@@ -121,43 +121,44 @@ var options = {
   plugins:  []
 };
 
-if (exportVar) {
-  if (exportVar === true) {
-    abort("Missing parameter of the -e/--export-var option.");
+function processOptionValues (optionName, callback, alias) {
+  if (optionName in argv) {
+    var optionValues = [].concat(argv[optionName]);
+    arrays.each(optionValues, function (optionValue) {
+      if (optionValue === true) {
+        var optionDisplay = "--" + optionName;
+        if (alias) {
+          optionDisplay = "-" + alias + "/" + optionDisplay;
+        }
+        abort("Missing parameter of the " + optionDisplay + " option.");
+      }
+      callback(optionValue);
+    });
   }
-  exportVar = argv["export-var"];
 }
+
+processOptionValues("export-var", function (e) {
+  exportVar = e;
+}, "e");
 
 options.cache = argv.cache;
 
-var allowedStartRules = argv["allowed-start-rules"];
-if (allowedStartRules) {
-  if (allowedStartRules === true) {
-    abort("Missing parameter of the --allowed-start-rules option.");
-  }
+processOptionValues("allowed-start-rules", function (allowedStartRules) {
   options.allowedStartRules = allowedStartRules
     .split(",")
     .map(trim);
-}
+});
 
 options.trace = argv.trace;
 
-var optimize = argv.optimize;
-if (optimize) {
-  if (optimize === true) {
-    abort("Missing parameter of the -o/--optimize option.");
-  }
+processOptionValues("optimize", function (optimize) {
   if (optimize !== "speed" && optimize !== "size") {
     abort("Optimization goal must be either \"speed\" or \"size\".");
   }
   options.optimize = optimize;
-}
+}, "o");
 
-var plugins = [].concat(argv.plugin || []);
-arrays.each(plugins, function (plugin) {
-  if (plugin === true) {
-    abort("Missing parameter of the --plugin option.");
-  }
+processOptionValues("plugin", function (plugin) {
   var id = /^(\.\/|\.\.\/)/.test(plugin) ? path.resolve(plugin) : plugin;
   var mod;
   try {
@@ -170,26 +171,19 @@ arrays.each(plugins, function (plugin) {
   options.plugins.push(mod);
 });
 
-var extraOptions = argv["extra-options"];
-if (extraOptions) {
-  if (extraOptions === true) {
-    abort("Missing parameter of the --extra-options option.");
-  }
+processOptionValues("extra-options", function (extraOptions) {
   addExtraOptions(options, extraOptions);
-}
+});
 
-var extraOptionsFile = argv["extra-options-file"];
-if (extraOptionsFile) {
-  if (extraOptionsFile === true) {
-    abort("Missing parameter of the --extra-options-file option.");
-  }
+processOptionValues("extra-options-file", function (extraOptionsFile) {
+  var json;
   try {
-    var json = fs.readFileSync(extraOptionsFile);
+    json = fs.readFileSync(extraOptionsFile);
   } catch(e) {
     abort("Can't read from file \"" + extraOptionsFile + "\".");
   }
   addExtraOptions(options, json);
-}
+});
 
 if (argv.version) {
   printVersion();

--- a/bin/pegjs
+++ b/bin/pegjs
@@ -136,7 +136,7 @@ while (args.length > 0 && isOption(args[0])) {
     case "--allowed-start-rules":
       nextArg();
       if (args.length === 0) {
-        abort("Missing parameter of the -e/--allowed-start-rules option.");
+        abort("Missing parameter of the --allowed-start-rules option.");
       }
       options.allowedStartRules = args[0]
         .split(",")

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
   "scripts":         {
     "test": "make hint && make spec"
   },
+  "dependencies": {
+    "minimist": "1.2.0"
+  },
   "devDependencies": {
     "browserify":   "11.2.0",
     "jasmine-node": "1.14.5",


### PR DESCRIPTION
This is very much a work in progress, but I wanted to get some feedback. I recommend viewing the diff with github's [whitespace](https://github.com/blog/967-github-secrets#whitespace) option: https://github.com/pegjs/pegjs/pull/383/files?w=true

Using [minimist](https://www.npmjs.com/package/minimist) to process CLI arguments makes the parsing code generally more flexible, and addresses the second part of #370:

> - [ ] Allow e.g. `--export-var=foo` (in addition to `--export-var foo`).

In addition, ba54ad03f5afb3710fe19e724a578e9c3a0e768e addresses the first part of #370:

> - [ ] Allow using `-` to mean standard input and output.

So far, my concern is that I might have accidentally broken something, given that there currently aren't any automated tests for the CLI.