### PR TITLE
Make `visitExpression` default visitor function always returns value from visitor

### DIFF
--- a/lib/compiler/visitor.js
+++ b/lib/compiler/visitor.js
@@ -15,7 +15,7 @@ var visitor = {
     function visitExpression(node) {
       var extraArgs = Array.prototype.slice.call(arguments, 1);
 
-      visit.apply(null, [node.expression].concat(extraArgs));
+      return visit.apply(null, [node.expression].concat(extraArgs));
     }
 
     function visitChildren(property) {


### PR DESCRIPTION
This is more awaited behaviour than returning nothing.