### PR TITLE
Issue #9: Add testes with |trace| option set to |true|.

### DIFF
--- a/spec/behavior/generated-parser-behavior.spec.js
+++ b/spec/behavior/generated-parser-behavior.spec.js
@@ -18,10 +18,14 @@ describe("generated parser behavior", function() {
     }
 
     var optionsVariants = [
-          { cache: false, optimize: "speed" },
-          { cache: false, optimize: "size"  },
-          { cache: true,  optimize: "speed" },
-          { cache: true,  optimize: "size"  },
+          { trace: false, cache: false, optimize: "speed" },
+          { trace: false, cache: false, optimize: "size"  },
+          { trace: false, cache: true,  optimize: "speed" },
+          { trace: false, cache: true,  optimize: "size"  },
+          { trace: true,  cache: false, optimize: "speed" },
+          { trace: true,  cache: false, optimize: "size"  },
+          { trace: true,  cache: true,  optimize: "speed" },
+          { trace: true,  cache: true,  optimize: "size"  },
         ],
         i;
 


### PR DESCRIPTION
You forgot to add them. When I wrote one of the my passes, the generator broke in case of trace option on. Now such errors will be caught by tests.