### PR TITLE
Optimize silent fails: remove checks that always false

### DIFF
--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const calcReportFailures = require( "./passes/calc-report-failures" );
 const generateBytecode = require( "./passes/generate-bytecode" );
 const generateJS = require( "./passes/generate-js" );
 const removeProxyRules = require( "./passes/remove-proxy-rules" );
@@ -56,6 +57,7 @@ const compiler = {
             removeProxyRules: removeProxyRules
         },
         generate: {
+            calcReportFailures: calcReportFailures,
             generateBytecode: generateBytecode,
             generateJS: generateJS
         }

--- a/lib/compiler/passes/calc-report-failures.js
+++ b/lib/compiler/passes/calc-report-failures.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const asts = require( "../asts" );
+const visitor = require( "../visitor" );
+
+// Determines if rule always used in disabled report failure context,
+// that means, that any failures, reported within it, are never will be
+// visible, so the no need to report it.
+function calcReportFailures( ast, options ) {
+
+    // By default, not report failures for rules...
+    ast.rules.forEach( rule => {
+
+        rule.reportFailures = false;
+
+    } );
+
+    // ...but report for start rules, because in that context report failures
+    // always enabled
+    const changedRules = options.allowedStartRules.map( name => {
+
+        const rule = asts.findRule( ast, name );
+
+        rule.reportFailures = true;
+
+        return rule;
+
+    } );
+
+    const calc = visitor.build( {
+        rule( node ) {
+
+            calc( node.expression );
+
+        },
+
+        // Because all rules already by default marked as not report any failures
+        // just break AST traversing when we need mark all referenced rules from
+        // this sub-AST as always not report anything (of course if it not be
+        // already marked as report failures).
+        named() {},
+
+        rule_ref( node ) {
+
+            const rule = asts.findRule( ast, node.name );
+
+            // This function only called when rule can report failures. If so, we
+            // need recalculate all rules that referenced from it. But do not do
+            // this twice - if rule is already marked, it was in `changedRules`.
+            if ( ! rule.reportFailures ) {
+
+                rule.reportFailures = true;
+                changedRules.push( rule );
+
+            }
+
+        }
+    } );
+
+    while ( changedRules.length > 0 ) {
+
+        calc( changedRules.pop() );
+
+    }
+
+}
+
+module.exports = calcReportFailures;

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -326,10 +326,10 @@ function generateBytecode( ast ) {
         rule( node ) {
 
             node.bytecode = generate( node.expression, {
-                sp: -1,             // stack pointer
-                env: { },           // mapping of label names to stack positions
-                action: null,       // action nodes pass themselves to children here
-                reportFailures: true// if `false`, suppress generation of EXPECT opcodes
+                sp: -1,                             // stack pointer
+                env: { },                           // mapping of label names to stack positions
+                action: null,                       // action nodes pass themselves to children here
+                reportFailures: node.reportFailures // if `false`, suppress generation of EXPECT opcodes
             } );
 
         },

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -269,7 +269,8 @@ function generateBytecode( ast ) {
             generate( expression, {
                 sp: context.sp + 1,
                 env: cloneEnv( context.env ),
-                action: null
+                action: null,
+                reportFailures: context.reportFailures
             } ),
             [ op.EXPECT_NS_END, negative ? 1 : 0 ],
             buildCondition(
@@ -325,25 +326,34 @@ function generateBytecode( ast ) {
         rule( node ) {
 
             node.bytecode = generate( node.expression, {
-                sp: -1,        // stack pointer
-                env: { },      // mapping of label names to stack positions
-                action: null   // action nodes pass themselves to children here
+                sp: -1,             // stack pointer
+                env: { },           // mapping of label names to stack positions
+                action: null,       // action nodes pass themselves to children here
+                reportFailures: true// if `false`, suppress generation of EXPECT opcodes
             } );
 
         },
 
         named( node, context ) {
 
-            const nameIndex = addConst(
+            // Do not generate unused constant, if no need it
+            const nameIndex = context.reportFailures ? addConst(
                 `peg$otherExpectation("${ js.stringEscape( node.name ) }")`
-            );
+            ) : null;
+            const expressionCode = generate( node.expression, {
+                sp: context.sp,
+                env: context.env,
+                action: context.action,
+                reportFailures: false
+            } );
 
-            return buildSequence(
+            // No need to disable report failures if it already disabled
+            return context.reportFailures ? buildSequence(
                 [ op.EXPECT, nameIndex ],
                 [ op.SILENT_FAILS_ON ],
-                generate( node.expression, context ),
+                expressionCode,
                 [ op.SILENT_FAILS_OFF ]
-            );
+            ) : expressionCode;
 
         },
 
@@ -355,7 +365,8 @@ function generateBytecode( ast ) {
                     generate( alternatives[ 0 ], {
                         sp: context.sp,
                         env: cloneEnv( context.env ),
-                        action: null
+                        action: null,
+                        reportFailures: context.reportFailures
                     } ),
                     alternatives.length < 2
                         ? []
@@ -382,7 +393,8 @@ function generateBytecode( ast ) {
             const expressionCode = generate( node.expression, {
                 sp: context.sp + ( emitCall ? 1 : 0 ),
                 env: env,
-                action: node
+                action: node,
+                reportFailures: context.reportFailures
             } );
             const functionIndex = addFunctionConst( Object.keys( env ), node.code );
 
@@ -416,14 +428,16 @@ function generateBytecode( ast ) {
                         generate( elements[ 0 ], {
                             sp: context.sp,
                             env: context.env,
-                            action: null
+                            action: null,
+                            reportFailures: context.reportFailures
                         } ),
                         buildCondition(
                             [ op.IF_NOT_ERROR ],
                             buildElementsCode( elements.slice( 1 ), {
                                 sp: context.sp + 1,
                                 env: context.env,
-                                action: context.action
+                                action: context.action,
+                                reportFailures: context.reportFailures
                             } ),
                             buildSequence(
                                 processedCount > 1 ? [ op.POP_N, processedCount ] : [ op.POP ],
@@ -460,7 +474,8 @@ function generateBytecode( ast ) {
                 buildElementsCode( node.elements, {
                     sp: context.sp + 1,
                     env: context.env,
-                    action: context.action
+                    action: context.action,
+                    reportFailures: context.reportFailures
                 } )
             );
 
@@ -475,7 +490,8 @@ function generateBytecode( ast ) {
             return generate( node.expression, {
                 sp: context.sp,
                 env: env,
-                action: null
+                action: null,
+                reportFailures: context.reportFailures
             } );
 
         },
@@ -487,7 +503,8 @@ function generateBytecode( ast ) {
                 generate( node.expression, {
                     sp: context.sp + 1,
                     env: cloneEnv( context.env ),
-                    action: null
+                    action: null,
+                    reportFailures: context.reportFailures
                 } ),
                 buildCondition(
                     [ op.IF_NOT_ERROR ],
@@ -516,7 +533,8 @@ function generateBytecode( ast ) {
                 generate( node.expression, {
                     sp: context.sp,
                     env: cloneEnv( context.env ),
-                    action: null
+                    action: null,
+                    reportFailures: context.reportFailures
                 } ),
                 buildCondition(
                     [ op.IF_ERROR ],
@@ -532,7 +550,8 @@ function generateBytecode( ast ) {
             const expressionCode = generate( node.expression, {
                 sp: context.sp + 1,
                 env: cloneEnv( context.env ),
-                action: null
+                action: null,
+                reportFailures: context.reportFailures
             } );
 
             return buildSequence(
@@ -549,7 +568,8 @@ function generateBytecode( ast ) {
             const expressionCode = generate( node.expression, {
                 sp: context.sp + 1,
                 env: cloneEnv( context.env ),
-                action: null
+                action: null,
+                reportFailures: context.reportFailures
             } );
 
             return buildSequence(
@@ -569,7 +589,8 @@ function generateBytecode( ast ) {
             return generate( node.expression, {
                 sp: context.sp,
                 env: cloneEnv( context.env ),
-                action: null
+                action: null,
+                reportFailures: context.reportFailures
             } );
 
         },
@@ -592,25 +613,26 @@ function generateBytecode( ast ) {
 
         },
 
-        literal( node ) {
+        literal( node, context ) {
 
             if ( node.value.length > 0 ) {
 
                 const stringIndex = addConst( `"${ js.stringEscape(
                     node.ignoreCase ? node.value.toLowerCase() : node.value
                 ) }"` );
-                const expectedIndex = addConst(
+                // Do not generate unused constant, if no need it
+                const expectedIndex = context.reportFailures ? addConst(
                     "peg$literalExpectation("
                     + `"${ js.stringEscape( node.value ) }", `
                     + node.ignoreCase
                     + ")"
-                );
+                ) : null;
 
                 // For case-sensitive strings the value must match the beginning of the
                 // remaining input exactly. As a result, we can use |ACCEPT_STRING| and
                 // save one |substr| call that would be needed if we used |ACCEPT_N|.
                 return buildSequence(
-                    [ op.EXPECT, expectedIndex ],
+                    context.reportFailures ? [ op.EXPECT, expectedIndex ] : [],
                     buildCondition(
                         node.ignoreCase
                             ? [ op.MATCH_STRING_IC, stringIndex ]
@@ -629,7 +651,7 @@ function generateBytecode( ast ) {
 
         },
 
-        class( node ) {
+        class( node, context ) {
 
             const regexp = "/^["
                 + ( node.inverted ? "^" : "" )
@@ -656,16 +678,17 @@ function generateBytecode( ast ) {
                 + "]";
 
             const regexpIndex = addConst( regexp );
-            const expectedIndex = addConst(
+            // Do not generate unused constant, if no need it
+            const expectedIndex = context.reportFailures ? addConst(
                 "peg$classExpectation("
                 + parts + ", "
                 + node.inverted + ", "
                 + node.ignoreCase
                 + ")"
-            );
+            ) : null;
 
             return buildSequence(
-                [ op.EXPECT, expectedIndex ],
+                context.reportFailures ? [ op.EXPECT, expectedIndex ] : [],
                 buildCondition(
                     [ op.MATCH_REGEXP, regexpIndex ],
                     [ op.ACCEPT_N, 1 ],
@@ -675,12 +698,15 @@ function generateBytecode( ast ) {
 
         },
 
-        any() {
+        any( node, context ) {
 
-            const expectedIndex = addConst( "peg$anyExpectation()" );
+            // Do not generate unused constant, if no need it
+            const expectedIndex = context.reportFailures
+                ? addConst( "peg$anyExpectation()" )
+                : null;
 
             return buildSequence(
-                [ op.EXPECT, expectedIndex ],
+                context.reportFailures ? [ op.EXPECT, expectedIndex ] : [],
                 buildCondition(
                     [ op.MATCH_ANY ],
                     [ op.ACCEPT_N, 1 ],

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -257,53 +257,41 @@ function peg$parse(input, options) {
   var peg$c34 = peg$anyExpectation();
   var peg$c35 = peg$otherExpectation("whitespace");
   var peg$c36 = "\t";
-  var peg$c37 = peg$literalExpectation("\t", false);
-  var peg$c38 = "\v";
-  var peg$c39 = peg$literalExpectation("\v", false);
-  var peg$c40 = "\f";
-  var peg$c41 = peg$literalExpectation("\f", false);
-  var peg$c42 = " ";
-  var peg$c43 = peg$literalExpectation(" ", false);
-  var peg$c44 = "\xA0";
-  var peg$c45 = peg$literalExpectation("\xA0", false);
-  var peg$c46 = "\uFEFF";
-  var peg$c47 = peg$literalExpectation("\uFEFF", false);
-  var peg$c48 = /^[\n\r\u2028\u2029]/;
-  var peg$c49 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false);
-  var peg$c50 = peg$otherExpectation("end of line");
-  var peg$c51 = "\n";
-  var peg$c52 = peg$literalExpectation("\n", false);
-  var peg$c53 = "\r\n";
-  var peg$c54 = peg$literalExpectation("\r\n", false);
-  var peg$c55 = "\r";
-  var peg$c56 = peg$literalExpectation("\r", false);
-  var peg$c57 = "\u2028";
-  var peg$c58 = peg$literalExpectation("\u2028", false);
-  var peg$c59 = "\u2029";
-  var peg$c60 = peg$literalExpectation("\u2029", false);
-  var peg$c61 = peg$otherExpectation("comment");
-  var peg$c62 = "/*";
-  var peg$c63 = peg$literalExpectation("/*", false);
-  var peg$c64 = "*/";
-  var peg$c65 = peg$literalExpectation("*/", false);
-  var peg$c66 = "//";
-  var peg$c67 = peg$literalExpectation("//", false);
-  var peg$c68 = function(name) { return name; };
-  var peg$c69 = peg$otherExpectation("identifier");
-  var peg$c70 = function(head, tail) { return head + tail.join(""); };
-  var peg$c71 = "_";
-  var peg$c72 = peg$literalExpectation("_", false);
-  var peg$c73 = "\\";
-  var peg$c74 = peg$literalExpectation("\\", false);
-  var peg$c75 = function(sequence) { return sequence; };
-  var peg$c76 = "\u200C";
-  var peg$c77 = peg$literalExpectation("\u200C", false);
-  var peg$c78 = "\u200D";
-  var peg$c79 = peg$literalExpectation("\u200D", false);
-  var peg$c80 = peg$otherExpectation("literal");
-  var peg$c81 = "i";
-  var peg$c82 = peg$literalExpectation("i", false);
-  var peg$c83 = function(value, ignoreCase) {
+  var peg$c37 = "\v";
+  var peg$c38 = "\f";
+  var peg$c39 = " ";
+  var peg$c40 = "\xA0";
+  var peg$c41 = "\uFEFF";
+  var peg$c42 = /^[\n\r\u2028\u2029]/;
+  var peg$c43 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false);
+  var peg$c44 = peg$otherExpectation("end of line");
+  var peg$c45 = "\n";
+  var peg$c46 = "\r\n";
+  var peg$c47 = "\r";
+  var peg$c48 = "\u2028";
+  var peg$c49 = "\u2029";
+  var peg$c50 = peg$otherExpectation("comment");
+  var peg$c51 = "/*";
+  var peg$c52 = "*/";
+  var peg$c53 = peg$literalExpectation("/*", false);
+  var peg$c54 = peg$literalExpectation("*/", false);
+  var peg$c55 = "//";
+  var peg$c56 = peg$literalExpectation("//", false);
+  var peg$c57 = function(name) { return name; };
+  var peg$c58 = peg$otherExpectation("identifier");
+  var peg$c59 = function(head, tail) { return head + tail.join(""); };
+  var peg$c60 = "_";
+  var peg$c61 = peg$literalExpectation("_", false);
+  var peg$c62 = "\\";
+  var peg$c63 = peg$literalExpectation("\\", false);
+  var peg$c64 = function(sequence) { return sequence; };
+  var peg$c65 = "\u200C";
+  var peg$c66 = peg$literalExpectation("\u200C", false);
+  var peg$c67 = "\u200D";
+  var peg$c68 = peg$literalExpectation("\u200D", false);
+  var peg$c69 = peg$otherExpectation("literal");
+  var peg$c70 = "i";
+  var peg$c71 = function(value, ignoreCase) {
         return {
           type: "literal",
           value: value,
@@ -311,21 +299,16 @@ function peg$parse(input, options) {
           location: location()
         };
       };
-  var peg$c84 = peg$otherExpectation("string");
-  var peg$c85 = "\"";
-  var peg$c86 = peg$literalExpectation("\"", false);
-  var peg$c87 = function(chars) { return chars.join(""); };
-  var peg$c88 = "'";
-  var peg$c89 = peg$literalExpectation("'", false);
-  var peg$c90 = function() { return text(); };
-  var peg$c91 = peg$otherExpectation("character class");
-  var peg$c92 = "[";
-  var peg$c93 = peg$literalExpectation("[", false);
-  var peg$c94 = "^";
-  var peg$c95 = peg$literalExpectation("^", false);
-  var peg$c96 = "]";
-  var peg$c97 = peg$literalExpectation("]", false);
-  var peg$c98 = function(inverted, parts, ignoreCase) {
+  var peg$c72 = peg$otherExpectation("string");
+  var peg$c73 = "\"";
+  var peg$c74 = function(chars) { return chars.join(""); };
+  var peg$c75 = "'";
+  var peg$c76 = function() { return text(); };
+  var peg$c77 = peg$otherExpectation("character class");
+  var peg$c78 = "[";
+  var peg$c79 = "^";
+  var peg$c80 = "]";
+  var peg$c81 = function(inverted, parts, ignoreCase) {
         return {
           type: "class",
           parts: parts.filter(part => part !== ""),
@@ -334,9 +317,8 @@ function peg$parse(input, options) {
           location: location()
         };
       };
-  var peg$c99 = "-";
-  var peg$c100 = peg$literalExpectation("-", false);
-  var peg$c101 = function(begin, end) {
+  var peg$c82 = "-";
+  var peg$c83 = function(begin, end) {
         if (begin.charCodeAt(0) > end.charCodeAt(0)) {
           error(
             "Invalid character range: " + text() + "."
@@ -345,147 +327,134 @@ function peg$parse(input, options) {
 
         return [begin, end];
       };
-  var peg$c102 = function() { return ""; };
-  var peg$c103 = "0";
-  var peg$c104 = peg$literalExpectation("0", false);
-  var peg$c105 = function() { return "\0"; };
-  var peg$c106 = "b";
-  var peg$c107 = peg$literalExpectation("b", false);
-  var peg$c108 = function() { return "\b"; };
-  var peg$c109 = "f";
-  var peg$c110 = peg$literalExpectation("f", false);
-  var peg$c111 = function() { return "\f"; };
-  var peg$c112 = "n";
-  var peg$c113 = peg$literalExpectation("n", false);
-  var peg$c114 = function() { return "\n"; };
-  var peg$c115 = "r";
-  var peg$c116 = peg$literalExpectation("r", false);
-  var peg$c117 = function() { return "\r"; };
-  var peg$c118 = "t";
-  var peg$c119 = peg$literalExpectation("t", false);
-  var peg$c120 = function() { return "\t"; };
-  var peg$c121 = "v";
-  var peg$c122 = peg$literalExpectation("v", false);
-  var peg$c123 = function() { return "\v"; };
-  var peg$c124 = "x";
-  var peg$c125 = peg$literalExpectation("x", false);
-  var peg$c126 = "u";
-  var peg$c127 = peg$literalExpectation("u", false);
-  var peg$c128 = function(digits) {
+  var peg$c84 = function() { return ""; };
+  var peg$c85 = "0";
+  var peg$c86 = function() { return "\0"; };
+  var peg$c87 = "b";
+  var peg$c88 = function() { return "\b"; };
+  var peg$c89 = "f";
+  var peg$c90 = function() { return "\f"; };
+  var peg$c91 = "n";
+  var peg$c92 = function() { return "\n"; };
+  var peg$c93 = "r";
+  var peg$c94 = function() { return "\r"; };
+  var peg$c95 = "t";
+  var peg$c96 = function() { return "\t"; };
+  var peg$c97 = "v";
+  var peg$c98 = function() { return "\v"; };
+  var peg$c99 = "x";
+  var peg$c100 = "u";
+  var peg$c101 = function(digits) {
         return String.fromCharCode(parseInt(digits, 16));
       };
-  var peg$c129 = /^[0-9]/;
-  var peg$c130 = peg$classExpectation([["0", "9"]], false, false);
-  var peg$c131 = /^[0-9a-f]/i;
-  var peg$c132 = peg$classExpectation([["0", "9"], ["a", "f"]], false, true);
-  var peg$c133 = ".";
-  var peg$c134 = peg$literalExpectation(".", false);
-  var peg$c135 = function() { return { type: "any", location: location() }; };
-  var peg$c136 = peg$otherExpectation("code block");
-  var peg$c137 = "{";
-  var peg$c138 = peg$literalExpectation("{", false);
-  var peg$c139 = "}";
-  var peg$c140 = peg$literalExpectation("}", false);
-  var peg$c141 = function(code) { return code; };
-  var peg$c142 = function() { error("Unbalanced brace."); };
-  var peg$c143 = /^[{}]/;
-  var peg$c144 = peg$classExpectation(["{", "}"], false, false);
-  var peg$c145 = /^[a-z\xB5\xDF-\xF6\xF8-\xFF\u0101\u0103\u0105\u0107\u0109\u010B\u010D\u010F\u0111\u0113\u0115\u0117\u0119\u011B\u011D\u011F\u0121\u0123\u0125\u0127\u0129\u012B\u012D\u012F\u0131\u0133\u0135\u0137-\u0138\u013A\u013C\u013E\u0140\u0142\u0144\u0146\u0148-\u0149\u014B\u014D\u014F\u0151\u0153\u0155\u0157\u0159\u015B\u015D\u015F\u0161\u0163\u0165\u0167\u0169\u016B\u016D\u016F\u0171\u0173\u0175\u0177\u017A\u017C\u017E-\u0180\u0183\u0185\u0188\u018C-\u018D\u0192\u0195\u0199-\u019B\u019E\u01A1\u01A3\u01A5\u01A8\u01AA-\u01AB\u01AD\u01B0\u01B4\u01B6\u01B9-\u01BA\u01BD-\u01BF\u01C6\u01C9\u01CC\u01CE\u01D0\u01D2\u01D4\u01D6\u01D8\u01DA\u01DC-\u01DD\u01DF\u01E1\u01E3\u01E5\u01E7\u01E9\u01EB\u01ED\u01EF-\u01F0\u01F3\u01F5\u01F9\u01FB\u01FD\u01FF\u0201\u0203\u0205\u0207\u0209\u020B\u020D\u020F\u0211\u0213\u0215\u0217\u0219\u021B\u021D\u021F\u0221\u0223\u0225\u0227\u0229\u022B\u022D\u022F\u0231\u0233-\u0239\u023C\u023F-\u0240\u0242\u0247\u0249\u024B\u024D\u024F-\u0293\u0295-\u02AF\u0371\u0373\u0377\u037B-\u037D\u0390\u03AC-\u03CE\u03D0-\u03D1\u03D5-\u03D7\u03D9\u03DB\u03DD\u03DF\u03E1\u03E3\u03E5\u03E7\u03E9\u03EB\u03ED\u03EF-\u03F3\u03F5\u03F8\u03FB-\u03FC\u0430-\u045F\u0461\u0463\u0465\u0467\u0469\u046B\u046D\u046F\u0471\u0473\u0475\u0477\u0479\u047B\u047D\u047F\u0481\u048B\u048D\u048F\u0491\u0493\u0495\u0497\u0499\u049B\u049D\u049F\u04A1\u04A3\u04A5\u04A7\u04A9\u04AB\u04AD\u04AF\u04B1\u04B3\u04B5\u04B7\u04B9\u04BB\u04BD\u04BF\u04C2\u04C4\u04C6\u04C8\u04CA\u04CC\u04CE-\u04CF\u04D1\u04D3\u04D5\u04D7\u04D9\u04DB\u04DD\u04DF\u04E1\u04E3\u04E5\u04E7\u04E9\u04EB\u04ED\u04EF\u04F1\u04F3\u04F5\u04F7\u04F9\u04FB\u04FD\u04FF\u0501\u0503\u0505\u0507\u0509\u050B\u050D\u050F\u0511\u0513\u0515\u0517\u0519\u051B\u051D\u051F\u0521\u0523\u0525\u0527\u0529\u052B\u052D\u052F\u0561-\u0587\u13F8-\u13FD\u1D00-\u1D2B\u1D6B-\u1D77\u1D79-\u1D9A\u1E01\u1E03\u1E05\u1E07\u1E09\u1E0B\u1E0D\u1E0F\u1E11\u1E13\u1E15\u1E17\u1E19\u1E1B\u1E1D\u1E1F\u1E21\u1E23\u1E25\u1E27\u1E29\u1E2B\u1E2D\u1E2F\u1E31\u1E33\u1E35\u1E37\u1E39\u1E3B\u1E3D\u1E3F\u1E41\u1E43\u1E45\u1E47\u1E49\u1E4B\u1E4D\u1E4F\u1E51\u1E53\u1E55\u1E57\u1E59\u1E5B\u1E5D\u1E5F\u1E61\u1E63\u1E65\u1E67\u1E69\u1E6B\u1E6D\u1E6F\u1E71\u1E73\u1E75\u1E77\u1E79\u1E7B\u1E7D\u1E7F\u1E81\u1E83\u1E85\u1E87\u1E89\u1E8B\u1E8D\u1E8F\u1E91\u1E93\u1E95-\u1E9D\u1E9F\u1EA1\u1EA3\u1EA5\u1EA7\u1EA9\u1EAB\u1EAD\u1EAF\u1EB1\u1EB3\u1EB5\u1EB7\u1EB9\u1EBB\u1EBD\u1EBF\u1EC1\u1EC3\u1EC5\u1EC7\u1EC9\u1ECB\u1ECD\u1ECF\u1ED1\u1ED3\u1ED5\u1ED7\u1ED9\u1EDB\u1EDD\u1EDF\u1EE1\u1EE3\u1EE5\u1EE7\u1EE9\u1EEB\u1EED\u1EEF\u1EF1\u1EF3\u1EF5\u1EF7\u1EF9\u1EFB\u1EFD\u1EFF-\u1F07\u1F10-\u1F15\u1F20-\u1F27\u1F30-\u1F37\u1F40-\u1F45\u1F50-\u1F57\u1F60-\u1F67\u1F70-\u1F7D\u1F80-\u1F87\u1F90-\u1F97\u1FA0-\u1FA7\u1FB0-\u1FB4\u1FB6-\u1FB7\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FC7\u1FD0-\u1FD3\u1FD6-\u1FD7\u1FE0-\u1FE7\u1FF2-\u1FF4\u1FF6-\u1FF7\u210A\u210E-\u210F\u2113\u212F\u2134\u2139\u213C-\u213D\u2146-\u2149\u214E\u2184\u2C30-\u2C5E\u2C61\u2C65-\u2C66\u2C68\u2C6A\u2C6C\u2C71\u2C73-\u2C74\u2C76-\u2C7B\u2C81\u2C83\u2C85\u2C87\u2C89\u2C8B\u2C8D\u2C8F\u2C91\u2C93\u2C95\u2C97\u2C99\u2C9B\u2C9D\u2C9F\u2CA1\u2CA3\u2CA5\u2CA7\u2CA9\u2CAB\u2CAD\u2CAF\u2CB1\u2CB3\u2CB5\u2CB7\u2CB9\u2CBB\u2CBD\u2CBF\u2CC1\u2CC3\u2CC5\u2CC7\u2CC9\u2CCB\u2CCD\u2CCF\u2CD1\u2CD3\u2CD5\u2CD7\u2CD9\u2CDB\u2CDD\u2CDF\u2CE1\u2CE3-\u2CE4\u2CEC\u2CEE\u2CF3\u2D00-\u2D25\u2D27\u2D2D\uA641\uA643\uA645\uA647\uA649\uA64B\uA64D\uA64F\uA651\uA653\uA655\uA657\uA659\uA65B\uA65D\uA65F\uA661\uA663\uA665\uA667\uA669\uA66B\uA66D\uA681\uA683\uA685\uA687\uA689\uA68B\uA68D\uA68F\uA691\uA693\uA695\uA697\uA699\uA69B\uA723\uA725\uA727\uA729\uA72B\uA72D\uA72F-\uA731\uA733\uA735\uA737\uA739\uA73B\uA73D\uA73F\uA741\uA743\uA745\uA747\uA749\uA74B\uA74D\uA74F\uA751\uA753\uA755\uA757\uA759\uA75B\uA75D\uA75F\uA761\uA763\uA765\uA767\uA769\uA76B\uA76D\uA76F\uA771-\uA778\uA77A\uA77C\uA77F\uA781\uA783\uA785\uA787\uA78C\uA78E\uA791\uA793-\uA795\uA797\uA799\uA79B\uA79D\uA79F\uA7A1\uA7A3\uA7A5\uA7A7\uA7A9\uA7B5\uA7B7\uA7FA\uAB30-\uAB5A\uAB60-\uAB65\uAB70-\uABBF\uFB00-\uFB06\uFB13-\uFB17\uFF41-\uFF5A]/;
-  var peg$c146 = peg$classExpectation([["a", "z"], "\xB5", ["\xDF", "\xF6"], ["\xF8", "\xFF"], "\u0101", "\u0103", "\u0105", "\u0107", "\u0109", "\u010B", "\u010D", "\u010F", "\u0111", "\u0113", "\u0115", "\u0117", "\u0119", "\u011B", "\u011D", "\u011F", "\u0121", "\u0123", "\u0125", "\u0127", "\u0129", "\u012B", "\u012D", "\u012F", "\u0131", "\u0133", "\u0135", ["\u0137", "\u0138"], "\u013A", "\u013C", "\u013E", "\u0140", "\u0142", "\u0144", "\u0146", ["\u0148", "\u0149"], "\u014B", "\u014D", "\u014F", "\u0151", "\u0153", "\u0155", "\u0157", "\u0159", "\u015B", "\u015D", "\u015F", "\u0161", "\u0163", "\u0165", "\u0167", "\u0169", "\u016B", "\u016D", "\u016F", "\u0171", "\u0173", "\u0175", "\u0177", "\u017A", "\u017C", ["\u017E", "\u0180"], "\u0183", "\u0185", "\u0188", ["\u018C", "\u018D"], "\u0192", "\u0195", ["\u0199", "\u019B"], "\u019E", "\u01A1", "\u01A3", "\u01A5", "\u01A8", ["\u01AA", "\u01AB"], "\u01AD", "\u01B0", "\u01B4", "\u01B6", ["\u01B9", "\u01BA"], ["\u01BD", "\u01BF"], "\u01C6", "\u01C9", "\u01CC", "\u01CE", "\u01D0", "\u01D2", "\u01D4", "\u01D6", "\u01D8", "\u01DA", ["\u01DC", "\u01DD"], "\u01DF", "\u01E1", "\u01E3", "\u01E5", "\u01E7", "\u01E9", "\u01EB", "\u01ED", ["\u01EF", "\u01F0"], "\u01F3", "\u01F5", "\u01F9", "\u01FB", "\u01FD", "\u01FF", "\u0201", "\u0203", "\u0205", "\u0207", "\u0209", "\u020B", "\u020D", "\u020F", "\u0211", "\u0213", "\u0215", "\u0217", "\u0219", "\u021B", "\u021D", "\u021F", "\u0221", "\u0223", "\u0225", "\u0227", "\u0229", "\u022B", "\u022D", "\u022F", "\u0231", ["\u0233", "\u0239"], "\u023C", ["\u023F", "\u0240"], "\u0242", "\u0247", "\u0249", "\u024B", "\u024D", ["\u024F", "\u0293"], ["\u0295", "\u02AF"], "\u0371", "\u0373", "\u0377", ["\u037B", "\u037D"], "\u0390", ["\u03AC", "\u03CE"], ["\u03D0", "\u03D1"], ["\u03D5", "\u03D7"], "\u03D9", "\u03DB", "\u03DD", "\u03DF", "\u03E1", "\u03E3", "\u03E5", "\u03E7", "\u03E9", "\u03EB", "\u03ED", ["\u03EF", "\u03F3"], "\u03F5", "\u03F8", ["\u03FB", "\u03FC"], ["\u0430", "\u045F"], "\u0461", "\u0463", "\u0465", "\u0467", "\u0469", "\u046B", "\u046D", "\u046F", "\u0471", "\u0473", "\u0475", "\u0477", "\u0479", "\u047B", "\u047D", "\u047F", "\u0481", "\u048B", "\u048D", "\u048F", "\u0491", "\u0493", "\u0495", "\u0497", "\u0499", "\u049B", "\u049D", "\u049F", "\u04A1", "\u04A3", "\u04A5", "\u04A7", "\u04A9", "\u04AB", "\u04AD", "\u04AF", "\u04B1", "\u04B3", "\u04B5", "\u04B7", "\u04B9", "\u04BB", "\u04BD", "\u04BF", "\u04C2", "\u04C4", "\u04C6", "\u04C8", "\u04CA", "\u04CC", ["\u04CE", "\u04CF"], "\u04D1", "\u04D3", "\u04D5", "\u04D7", "\u04D9", "\u04DB", "\u04DD", "\u04DF", "\u04E1", "\u04E3", "\u04E5", "\u04E7", "\u04E9", "\u04EB", "\u04ED", "\u04EF", "\u04F1", "\u04F3", "\u04F5", "\u04F7", "\u04F9", "\u04FB", "\u04FD", "\u04FF", "\u0501", "\u0503", "\u0505", "\u0507", "\u0509", "\u050B", "\u050D", "\u050F", "\u0511", "\u0513", "\u0515", "\u0517", "\u0519", "\u051B", "\u051D", "\u051F", "\u0521", "\u0523", "\u0525", "\u0527", "\u0529", "\u052B", "\u052D", "\u052F", ["\u0561", "\u0587"], ["\u13F8", "\u13FD"], ["\u1D00", "\u1D2B"], ["\u1D6B", "\u1D77"], ["\u1D79", "\u1D9A"], "\u1E01", "\u1E03", "\u1E05", "\u1E07", "\u1E09", "\u1E0B", "\u1E0D", "\u1E0F", "\u1E11", "\u1E13", "\u1E15", "\u1E17", "\u1E19", "\u1E1B", "\u1E1D", "\u1E1F", "\u1E21", "\u1E23", "\u1E25", "\u1E27", "\u1E29", "\u1E2B", "\u1E2D", "\u1E2F", "\u1E31", "\u1E33", "\u1E35", "\u1E37", "\u1E39", "\u1E3B", "\u1E3D", "\u1E3F", "\u1E41", "\u1E43", "\u1E45", "\u1E47", "\u1E49", "\u1E4B", "\u1E4D", "\u1E4F", "\u1E51", "\u1E53", "\u1E55", "\u1E57", "\u1E59", "\u1E5B", "\u1E5D", "\u1E5F", "\u1E61", "\u1E63", "\u1E65", "\u1E67", "\u1E69", "\u1E6B", "\u1E6D", "\u1E6F", "\u1E71", "\u1E73", "\u1E75", "\u1E77", "\u1E79", "\u1E7B", "\u1E7D", "\u1E7F", "\u1E81", "\u1E83", "\u1E85", "\u1E87", "\u1E89", "\u1E8B", "\u1E8D", "\u1E8F", "\u1E91", "\u1E93", ["\u1E95", "\u1E9D"], "\u1E9F", "\u1EA1", "\u1EA3", "\u1EA5", "\u1EA7", "\u1EA9", "\u1EAB", "\u1EAD", "\u1EAF", "\u1EB1", "\u1EB3", "\u1EB5", "\u1EB7", "\u1EB9", "\u1EBB", "\u1EBD", "\u1EBF", "\u1EC1", "\u1EC3", "\u1EC5", "\u1EC7", "\u1EC9", "\u1ECB", "\u1ECD", "\u1ECF", "\u1ED1", "\u1ED3", "\u1ED5", "\u1ED7", "\u1ED9", "\u1EDB", "\u1EDD", "\u1EDF", "\u1EE1", "\u1EE3", "\u1EE5", "\u1EE7", "\u1EE9", "\u1EEB", "\u1EED", "\u1EEF", "\u1EF1", "\u1EF3", "\u1EF5", "\u1EF7", "\u1EF9", "\u1EFB", "\u1EFD", ["\u1EFF", "\u1F07"], ["\u1F10", "\u1F15"], ["\u1F20", "\u1F27"], ["\u1F30", "\u1F37"], ["\u1F40", "\u1F45"], ["\u1F50", "\u1F57"], ["\u1F60", "\u1F67"], ["\u1F70", "\u1F7D"], ["\u1F80", "\u1F87"], ["\u1F90", "\u1F97"], ["\u1FA0", "\u1FA7"], ["\u1FB0", "\u1FB4"], ["\u1FB6", "\u1FB7"], "\u1FBE", ["\u1FC2", "\u1FC4"], ["\u1FC6", "\u1FC7"], ["\u1FD0", "\u1FD3"], ["\u1FD6", "\u1FD7"], ["\u1FE0", "\u1FE7"], ["\u1FF2", "\u1FF4"], ["\u1FF6", "\u1FF7"], "\u210A", ["\u210E", "\u210F"], "\u2113", "\u212F", "\u2134", "\u2139", ["\u213C", "\u213D"], ["\u2146", "\u2149"], "\u214E", "\u2184", ["\u2C30", "\u2C5E"], "\u2C61", ["\u2C65", "\u2C66"], "\u2C68", "\u2C6A", "\u2C6C", "\u2C71", ["\u2C73", "\u2C74"], ["\u2C76", "\u2C7B"], "\u2C81", "\u2C83", "\u2C85", "\u2C87", "\u2C89", "\u2C8B", "\u2C8D", "\u2C8F", "\u2C91", "\u2C93", "\u2C95", "\u2C97", "\u2C99", "\u2C9B", "\u2C9D", "\u2C9F", "\u2CA1", "\u2CA3", "\u2CA5", "\u2CA7", "\u2CA9", "\u2CAB", "\u2CAD", "\u2CAF", "\u2CB1", "\u2CB3", "\u2CB5", "\u2CB7", "\u2CB9", "\u2CBB", "\u2CBD", "\u2CBF", "\u2CC1", "\u2CC3", "\u2CC5", "\u2CC7", "\u2CC9", "\u2CCB", "\u2CCD", "\u2CCF", "\u2CD1", "\u2CD3", "\u2CD5", "\u2CD7", "\u2CD9", "\u2CDB", "\u2CDD", "\u2CDF", "\u2CE1", ["\u2CE3", "\u2CE4"], "\u2CEC", "\u2CEE", "\u2CF3", ["\u2D00", "\u2D25"], "\u2D27", "\u2D2D", "\uA641", "\uA643", "\uA645", "\uA647", "\uA649", "\uA64B", "\uA64D", "\uA64F", "\uA651", "\uA653", "\uA655", "\uA657", "\uA659", "\uA65B", "\uA65D", "\uA65F", "\uA661", "\uA663", "\uA665", "\uA667", "\uA669", "\uA66B", "\uA66D", "\uA681", "\uA683", "\uA685", "\uA687", "\uA689", "\uA68B", "\uA68D", "\uA68F", "\uA691", "\uA693", "\uA695", "\uA697", "\uA699", "\uA69B", "\uA723", "\uA725", "\uA727", "\uA729", "\uA72B", "\uA72D", ["\uA72F", "\uA731"], "\uA733", "\uA735", "\uA737", "\uA739", "\uA73B", "\uA73D", "\uA73F", "\uA741", "\uA743", "\uA745", "\uA747", "\uA749", "\uA74B", "\uA74D", "\uA74F", "\uA751", "\uA753", "\uA755", "\uA757", "\uA759", "\uA75B", "\uA75D", "\uA75F", "\uA761", "\uA763", "\uA765", "\uA767", "\uA769", "\uA76B", "\uA76D", "\uA76F", ["\uA771", "\uA778"], "\uA77A", "\uA77C", "\uA77F", "\uA781", "\uA783", "\uA785", "\uA787", "\uA78C", "\uA78E", "\uA791", ["\uA793", "\uA795"], "\uA797", "\uA799", "\uA79B", "\uA79D", "\uA79F", "\uA7A1", "\uA7A3", "\uA7A5", "\uA7A7", "\uA7A9", "\uA7B5", "\uA7B7", "\uA7FA", ["\uAB30", "\uAB5A"], ["\uAB60", "\uAB65"], ["\uAB70", "\uABBF"], ["\uFB00", "\uFB06"], ["\uFB13", "\uFB17"], ["\uFF41", "\uFF5A"]], false, false);
-  var peg$c147 = /^[\u02B0-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0374\u037A\u0559\u0640\u06E5-\u06E6\u07F4-\u07F5\u07FA\u081A\u0824\u0828\u0971\u0E46\u0EC6\u10FC\u17D7\u1843\u1AA7\u1C78-\u1C7D\u1D2C-\u1D6A\u1D78\u1D9B-\u1DBF\u2071\u207F\u2090-\u209C\u2C7C-\u2C7D\u2D6F\u2E2F\u3005\u3031-\u3035\u303B\u309D-\u309E\u30FC-\u30FE\uA015\uA4F8-\uA4FD\uA60C\uA67F\uA69C-\uA69D\uA717-\uA71F\uA770\uA788\uA7F8-\uA7F9\uA9CF\uA9E6\uAA70\uAADD\uAAF3-\uAAF4\uAB5C-\uAB5F\uFF70\uFF9E-\uFF9F]/;
-  var peg$c148 = peg$classExpectation([["\u02B0", "\u02C1"], ["\u02C6", "\u02D1"], ["\u02E0", "\u02E4"], "\u02EC", "\u02EE", "\u0374", "\u037A", "\u0559", "\u0640", ["\u06E5", "\u06E6"], ["\u07F4", "\u07F5"], "\u07FA", "\u081A", "\u0824", "\u0828", "\u0971", "\u0E46", "\u0EC6", "\u10FC", "\u17D7", "\u1843", "\u1AA7", ["\u1C78", "\u1C7D"], ["\u1D2C", "\u1D6A"], "\u1D78", ["\u1D9B", "\u1DBF"], "\u2071", "\u207F", ["\u2090", "\u209C"], ["\u2C7C", "\u2C7D"], "\u2D6F", "\u2E2F", "\u3005", ["\u3031", "\u3035"], "\u303B", ["\u309D", "\u309E"], ["\u30FC", "\u30FE"], "\uA015", ["\uA4F8", "\uA4FD"], "\uA60C", "\uA67F", ["\uA69C", "\uA69D"], ["\uA717", "\uA71F"], "\uA770", "\uA788", ["\uA7F8", "\uA7F9"], "\uA9CF", "\uA9E6", "\uAA70", "\uAADD", ["\uAAF3", "\uAAF4"], ["\uAB5C", "\uAB5F"], "\uFF70", ["\uFF9E", "\uFF9F"]], false, false);
-  var peg$c149 = /^[\xAA\xBA\u01BB\u01C0-\u01C3\u0294\u05D0-\u05EA\u05F0-\u05F2\u0620-\u063F\u0641-\u064A\u066E-\u066F\u0671-\u06D3\u06D5\u06EE-\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u0800-\u0815\u0840-\u0858\u08A0-\u08B4\u0904-\u0939\u093D\u0950\u0958-\u0961\u0972-\u0980\u0985-\u098C\u098F-\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC-\u09DD\u09DF-\u09E1\u09F0-\u09F1\u0A05-\u0A0A\u0A0F-\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32-\u0A33\u0A35-\u0A36\u0A38-\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2-\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0-\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F-\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32-\u0B33\u0B35-\u0B39\u0B3D\u0B5C-\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99-\u0B9A\u0B9C\u0B9E-\u0B9F\u0BA3-\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C60-\u0C61\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0-\u0CE1\u0CF1-\u0CF2\u0D05-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32-\u0E33\u0E40-\u0E45\u0E81-\u0E82\u0E84\u0E87-\u0E88\u0E8A\u0E8D\u0E94-\u0E97\u0E99-\u0E9F\u0EA1-\u0EA3\u0EA5\u0EA7\u0EAA-\u0EAB\u0EAD-\u0EB0\u0EB2-\u0EB3\u0EBD\u0EC0-\u0EC4\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065-\u1066\u106E-\u1070\u1075-\u1081\u108E\u10D0-\u10FA\u10FD-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16F1-\u16F8\u1700-\u170C\u170E-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17DC\u1820-\u1842\u1844-\u1877\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1B05-\u1B33\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE-\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C77\u1CE9-\u1CEC\u1CEE-\u1CF1\u1CF5-\u1CF6\u2135-\u2138\u2D30-\u2D67\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3006\u303C\u3041-\u3096\u309F\u30A1-\u30FA\u30FF\u3105-\u312D\u3131-\u318E\u31A0-\u31BA\u31F0-\u31FF\u3400-\u4DB5\u4E00-\u9FD5\uA000-\uA014\uA016-\uA48C\uA4D0-\uA4F7\uA500-\uA60B\uA610-\uA61F\uA62A-\uA62B\uA66E\uA6A0-\uA6E5\uA78F\uA7F7\uA7FB-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9E0-\uA9E4\uA9E7-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA6F\uAA71-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5-\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADC\uAAE0-\uAAEA\uAAF2\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uABC0-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40-\uFB41\uFB43-\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF66-\uFF6F\uFF71-\uFF9D\uFFA0-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC]/;
-  var peg$c150 = peg$classExpectation(["\xAA", "\xBA", "\u01BB", ["\u01C0", "\u01C3"], "\u0294", ["\u05D0", "\u05EA"], ["\u05F0", "\u05F2"], ["\u0620", "\u063F"], ["\u0641", "\u064A"], ["\u066E", "\u066F"], ["\u0671", "\u06D3"], "\u06D5", ["\u06EE", "\u06EF"], ["\u06FA", "\u06FC"], "\u06FF", "\u0710", ["\u0712", "\u072F"], ["\u074D", "\u07A5"], "\u07B1", ["\u07CA", "\u07EA"], ["\u0800", "\u0815"], ["\u0840", "\u0858"], ["\u08A0", "\u08B4"], ["\u0904", "\u0939"], "\u093D", "\u0950", ["\u0958", "\u0961"], ["\u0972", "\u0980"], ["\u0985", "\u098C"], ["\u098F", "\u0990"], ["\u0993", "\u09A8"], ["\u09AA", "\u09B0"], "\u09B2", ["\u09B6", "\u09B9"], "\u09BD", "\u09CE", ["\u09DC", "\u09DD"], ["\u09DF", "\u09E1"], ["\u09F0", "\u09F1"], ["\u0A05", "\u0A0A"], ["\u0A0F", "\u0A10"], ["\u0A13", "\u0A28"], ["\u0A2A", "\u0A30"], ["\u0A32", "\u0A33"], ["\u0A35", "\u0A36"], ["\u0A38", "\u0A39"], ["\u0A59", "\u0A5C"], "\u0A5E", ["\u0A72", "\u0A74"], ["\u0A85", "\u0A8D"], ["\u0A8F", "\u0A91"], ["\u0A93", "\u0AA8"], ["\u0AAA", "\u0AB0"], ["\u0AB2", "\u0AB3"], ["\u0AB5", "\u0AB9"], "\u0ABD", "\u0AD0", ["\u0AE0", "\u0AE1"], "\u0AF9", ["\u0B05", "\u0B0C"], ["\u0B0F", "\u0B10"], ["\u0B13", "\u0B28"], ["\u0B2A", "\u0B30"], ["\u0B32", "\u0B33"], ["\u0B35", "\u0B39"], "\u0B3D", ["\u0B5C", "\u0B5D"], ["\u0B5F", "\u0B61"], "\u0B71", "\u0B83", ["\u0B85", "\u0B8A"], ["\u0B8E", "\u0B90"], ["\u0B92", "\u0B95"], ["\u0B99", "\u0B9A"], "\u0B9C", ["\u0B9E", "\u0B9F"], ["\u0BA3", "\u0BA4"], ["\u0BA8", "\u0BAA"], ["\u0BAE", "\u0BB9"], "\u0BD0", ["\u0C05", "\u0C0C"], ["\u0C0E", "\u0C10"], ["\u0C12", "\u0C28"], ["\u0C2A", "\u0C39"], "\u0C3D", ["\u0C58", "\u0C5A"], ["\u0C60", "\u0C61"], ["\u0C85", "\u0C8C"], ["\u0C8E", "\u0C90"], ["\u0C92", "\u0CA8"], ["\u0CAA", "\u0CB3"], ["\u0CB5", "\u0CB9"], "\u0CBD", "\u0CDE", ["\u0CE0", "\u0CE1"], ["\u0CF1", "\u0CF2"], ["\u0D05", "\u0D0C"], ["\u0D0E", "\u0D10"], ["\u0D12", "\u0D3A"], "\u0D3D", "\u0D4E", ["\u0D5F", "\u0D61"], ["\u0D7A", "\u0D7F"], ["\u0D85", "\u0D96"], ["\u0D9A", "\u0DB1"], ["\u0DB3", "\u0DBB"], "\u0DBD", ["\u0DC0", "\u0DC6"], ["\u0E01", "\u0E30"], ["\u0E32", "\u0E33"], ["\u0E40", "\u0E45"], ["\u0E81", "\u0E82"], "\u0E84", ["\u0E87", "\u0E88"], "\u0E8A", "\u0E8D", ["\u0E94", "\u0E97"], ["\u0E99", "\u0E9F"], ["\u0EA1", "\u0EA3"], "\u0EA5", "\u0EA7", ["\u0EAA", "\u0EAB"], ["\u0EAD", "\u0EB0"], ["\u0EB2", "\u0EB3"], "\u0EBD", ["\u0EC0", "\u0EC4"], ["\u0EDC", "\u0EDF"], "\u0F00", ["\u0F40", "\u0F47"], ["\u0F49", "\u0F6C"], ["\u0F88", "\u0F8C"], ["\u1000", "\u102A"], "\u103F", ["\u1050", "\u1055"], ["\u105A", "\u105D"], "\u1061", ["\u1065", "\u1066"], ["\u106E", "\u1070"], ["\u1075", "\u1081"], "\u108E", ["\u10D0", "\u10FA"], ["\u10FD", "\u1248"], ["\u124A", "\u124D"], ["\u1250", "\u1256"], "\u1258", ["\u125A", "\u125D"], ["\u1260", "\u1288"], ["\u128A", "\u128D"], ["\u1290", "\u12B0"], ["\u12B2", "\u12B5"], ["\u12B8", "\u12BE"], "\u12C0", ["\u12C2", "\u12C5"], ["\u12C8", "\u12D6"], ["\u12D8", "\u1310"], ["\u1312", "\u1315"], ["\u1318", "\u135A"], ["\u1380", "\u138F"], ["\u1401", "\u166C"], ["\u166F", "\u167F"], ["\u1681", "\u169A"], ["\u16A0", "\u16EA"], ["\u16F1", "\u16F8"], ["\u1700", "\u170C"], ["\u170E", "\u1711"], ["\u1720", "\u1731"], ["\u1740", "\u1751"], ["\u1760", "\u176C"], ["\u176E", "\u1770"], ["\u1780", "\u17B3"], "\u17DC", ["\u1820", "\u1842"], ["\u1844", "\u1877"], ["\u1880", "\u18A8"], "\u18AA", ["\u18B0", "\u18F5"], ["\u1900", "\u191E"], ["\u1950", "\u196D"], ["\u1970", "\u1974"], ["\u1980", "\u19AB"], ["\u19B0", "\u19C9"], ["\u1A00", "\u1A16"], ["\u1A20", "\u1A54"], ["\u1B05", "\u1B33"], ["\u1B45", "\u1B4B"], ["\u1B83", "\u1BA0"], ["\u1BAE", "\u1BAF"], ["\u1BBA", "\u1BE5"], ["\u1C00", "\u1C23"], ["\u1C4D", "\u1C4F"], ["\u1C5A", "\u1C77"], ["\u1CE9", "\u1CEC"], ["\u1CEE", "\u1CF1"], ["\u1CF5", "\u1CF6"], ["\u2135", "\u2138"], ["\u2D30", "\u2D67"], ["\u2D80", "\u2D96"], ["\u2DA0", "\u2DA6"], ["\u2DA8", "\u2DAE"], ["\u2DB0", "\u2DB6"], ["\u2DB8", "\u2DBE"], ["\u2DC0", "\u2DC6"], ["\u2DC8", "\u2DCE"], ["\u2DD0", "\u2DD6"], ["\u2DD8", "\u2DDE"], "\u3006", "\u303C", ["\u3041", "\u3096"], "\u309F", ["\u30A1", "\u30FA"], "\u30FF", ["\u3105", "\u312D"], ["\u3131", "\u318E"], ["\u31A0", "\u31BA"], ["\u31F0", "\u31FF"], ["\u3400", "\u4DB5"], ["\u4E00", "\u9FD5"], ["\uA000", "\uA014"], ["\uA016", "\uA48C"], ["\uA4D0", "\uA4F7"], ["\uA500", "\uA60B"], ["\uA610", "\uA61F"], ["\uA62A", "\uA62B"], "\uA66E", ["\uA6A0", "\uA6E5"], "\uA78F", "\uA7F7", ["\uA7FB", "\uA801"], ["\uA803", "\uA805"], ["\uA807", "\uA80A"], ["\uA80C", "\uA822"], ["\uA840", "\uA873"], ["\uA882", "\uA8B3"], ["\uA8F2", "\uA8F7"], "\uA8FB", "\uA8FD", ["\uA90A", "\uA925"], ["\uA930", "\uA946"], ["\uA960", "\uA97C"], ["\uA984", "\uA9B2"], ["\uA9E0", "\uA9E4"], ["\uA9E7", "\uA9EF"], ["\uA9FA", "\uA9FE"], ["\uAA00", "\uAA28"], ["\uAA40", "\uAA42"], ["\uAA44", "\uAA4B"], ["\uAA60", "\uAA6F"], ["\uAA71", "\uAA76"], "\uAA7A", ["\uAA7E", "\uAAAF"], "\uAAB1", ["\uAAB5", "\uAAB6"], ["\uAAB9", "\uAABD"], "\uAAC0", "\uAAC2", ["\uAADB", "\uAADC"], ["\uAAE0", "\uAAEA"], "\uAAF2", ["\uAB01", "\uAB06"], ["\uAB09", "\uAB0E"], ["\uAB11", "\uAB16"], ["\uAB20", "\uAB26"], ["\uAB28", "\uAB2E"], ["\uABC0", "\uABE2"], ["\uAC00", "\uD7A3"], ["\uD7B0", "\uD7C6"], ["\uD7CB", "\uD7FB"], ["\uF900", "\uFA6D"], ["\uFA70", "\uFAD9"], "\uFB1D", ["\uFB1F", "\uFB28"], ["\uFB2A", "\uFB36"], ["\uFB38", "\uFB3C"], "\uFB3E", ["\uFB40", "\uFB41"], ["\uFB43", "\uFB44"], ["\uFB46", "\uFBB1"], ["\uFBD3", "\uFD3D"], ["\uFD50", "\uFD8F"], ["\uFD92", "\uFDC7"], ["\uFDF0", "\uFDFB"], ["\uFE70", "\uFE74"], ["\uFE76", "\uFEFC"], ["\uFF66", "\uFF6F"], ["\uFF71", "\uFF9D"], ["\uFFA0", "\uFFBE"], ["\uFFC2", "\uFFC7"], ["\uFFCA", "\uFFCF"], ["\uFFD2", "\uFFD7"], ["\uFFDA", "\uFFDC"]], false, false);
-  var peg$c151 = /^[\u01C5\u01C8\u01CB\u01F2\u1F88-\u1F8F\u1F98-\u1F9F\u1FA8-\u1FAF\u1FBC\u1FCC\u1FFC]/;
-  var peg$c152 = peg$classExpectation(["\u01C5", "\u01C8", "\u01CB", "\u01F2", ["\u1F88", "\u1F8F"], ["\u1F98", "\u1F9F"], ["\u1FA8", "\u1FAF"], "\u1FBC", "\u1FCC", "\u1FFC"], false, false);
-  var peg$c153 = /^[A-Z\xC0-\xD6\xD8-\xDE\u0100\u0102\u0104\u0106\u0108\u010A\u010C\u010E\u0110\u0112\u0114\u0116\u0118\u011A\u011C\u011E\u0120\u0122\u0124\u0126\u0128\u012A\u012C\u012E\u0130\u0132\u0134\u0136\u0139\u013B\u013D\u013F\u0141\u0143\u0145\u0147\u014A\u014C\u014E\u0150\u0152\u0154\u0156\u0158\u015A\u015C\u015E\u0160\u0162\u0164\u0166\u0168\u016A\u016C\u016E\u0170\u0172\u0174\u0176\u0178-\u0179\u017B\u017D\u0181-\u0182\u0184\u0186-\u0187\u0189-\u018B\u018E-\u0191\u0193-\u0194\u0196-\u0198\u019C-\u019D\u019F-\u01A0\u01A2\u01A4\u01A6-\u01A7\u01A9\u01AC\u01AE-\u01AF\u01B1-\u01B3\u01B5\u01B7-\u01B8\u01BC\u01C4\u01C7\u01CA\u01CD\u01CF\u01D1\u01D3\u01D5\u01D7\u01D9\u01DB\u01DE\u01E0\u01E2\u01E4\u01E6\u01E8\u01EA\u01EC\u01EE\u01F1\u01F4\u01F6-\u01F8\u01FA\u01FC\u01FE\u0200\u0202\u0204\u0206\u0208\u020A\u020C\u020E\u0210\u0212\u0214\u0216\u0218\u021A\u021C\u021E\u0220\u0222\u0224\u0226\u0228\u022A\u022C\u022E\u0230\u0232\u023A-\u023B\u023D-\u023E\u0241\u0243-\u0246\u0248\u024A\u024C\u024E\u0370\u0372\u0376\u037F\u0386\u0388-\u038A\u038C\u038E-\u038F\u0391-\u03A1\u03A3-\u03AB\u03CF\u03D2-\u03D4\u03D8\u03DA\u03DC\u03DE\u03E0\u03E2\u03E4\u03E6\u03E8\u03EA\u03EC\u03EE\u03F4\u03F7\u03F9-\u03FA\u03FD-\u042F\u0460\u0462\u0464\u0466\u0468\u046A\u046C\u046E\u0470\u0472\u0474\u0476\u0478\u047A\u047C\u047E\u0480\u048A\u048C\u048E\u0490\u0492\u0494\u0496\u0498\u049A\u049C\u049E\u04A0\u04A2\u04A4\u04A6\u04A8\u04AA\u04AC\u04AE\u04B0\u04B2\u04B4\u04B6\u04B8\u04BA\u04BC\u04BE\u04C0-\u04C1\u04C3\u04C5\u04C7\u04C9\u04CB\u04CD\u04D0\u04D2\u04D4\u04D6\u04D8\u04DA\u04DC\u04DE\u04E0\u04E2\u04E4\u04E6\u04E8\u04EA\u04EC\u04EE\u04F0\u04F2\u04F4\u04F6\u04F8\u04FA\u04FC\u04FE\u0500\u0502\u0504\u0506\u0508\u050A\u050C\u050E\u0510\u0512\u0514\u0516\u0518\u051A\u051C\u051E\u0520\u0522\u0524\u0526\u0528\u052A\u052C\u052E\u0531-\u0556\u10A0-\u10C5\u10C7\u10CD\u13A0-\u13F5\u1E00\u1E02\u1E04\u1E06\u1E08\u1E0A\u1E0C\u1E0E\u1E10\u1E12\u1E14\u1E16\u1E18\u1E1A\u1E1C\u1E1E\u1E20\u1E22\u1E24\u1E26\u1E28\u1E2A\u1E2C\u1E2E\u1E30\u1E32\u1E34\u1E36\u1E38\u1E3A\u1E3C\u1E3E\u1E40\u1E42\u1E44\u1E46\u1E48\u1E4A\u1E4C\u1E4E\u1E50\u1E52\u1E54\u1E56\u1E58\u1E5A\u1E5C\u1E5E\u1E60\u1E62\u1E64\u1E66\u1E68\u1E6A\u1E6C\u1E6E\u1E70\u1E72\u1E74\u1E76\u1E78\u1E7A\u1E7C\u1E7E\u1E80\u1E82\u1E84\u1E86\u1E88\u1E8A\u1E8C\u1E8E\u1E90\u1E92\u1E94\u1E9E\u1EA0\u1EA2\u1EA4\u1EA6\u1EA8\u1EAA\u1EAC\u1EAE\u1EB0\u1EB2\u1EB4\u1EB6\u1EB8\u1EBA\u1EBC\u1EBE\u1EC0\u1EC2\u1EC4\u1EC6\u1EC8\u1ECA\u1ECC\u1ECE\u1ED0\u1ED2\u1ED4\u1ED6\u1ED8\u1EDA\u1EDC\u1EDE\u1EE0\u1EE2\u1EE4\u1EE6\u1EE8\u1EEA\u1EEC\u1EEE\u1EF0\u1EF2\u1EF4\u1EF6\u1EF8\u1EFA\u1EFC\u1EFE\u1F08-\u1F0F\u1F18-\u1F1D\u1F28-\u1F2F\u1F38-\u1F3F\u1F48-\u1F4D\u1F59\u1F5B\u1F5D\u1F5F\u1F68-\u1F6F\u1FB8-\u1FBB\u1FC8-\u1FCB\u1FD8-\u1FDB\u1FE8-\u1FEC\u1FF8-\u1FFB\u2102\u2107\u210B-\u210D\u2110-\u2112\u2115\u2119-\u211D\u2124\u2126\u2128\u212A-\u212D\u2130-\u2133\u213E-\u213F\u2145\u2183\u2C00-\u2C2E\u2C60\u2C62-\u2C64\u2C67\u2C69\u2C6B\u2C6D-\u2C70\u2C72\u2C75\u2C7E-\u2C80\u2C82\u2C84\u2C86\u2C88\u2C8A\u2C8C\u2C8E\u2C90\u2C92\u2C94\u2C96\u2C98\u2C9A\u2C9C\u2C9E\u2CA0\u2CA2\u2CA4\u2CA6\u2CA8\u2CAA\u2CAC\u2CAE\u2CB0\u2CB2\u2CB4\u2CB6\u2CB8\u2CBA\u2CBC\u2CBE\u2CC0\u2CC2\u2CC4\u2CC6\u2CC8\u2CCA\u2CCC\u2CCE\u2CD0\u2CD2\u2CD4\u2CD6\u2CD8\u2CDA\u2CDC\u2CDE\u2CE0\u2CE2\u2CEB\u2CED\u2CF2\uA640\uA642\uA644\uA646\uA648\uA64A\uA64C\uA64E\uA650\uA652\uA654\uA656\uA658\uA65A\uA65C\uA65E\uA660\uA662\uA664\uA666\uA668\uA66A\uA66C\uA680\uA682\uA684\uA686\uA688\uA68A\uA68C\uA68E\uA690\uA692\uA694\uA696\uA698\uA69A\uA722\uA724\uA726\uA728\uA72A\uA72C\uA72E\uA732\uA734\uA736\uA738\uA73A\uA73C\uA73E\uA740\uA742\uA744\uA746\uA748\uA74A\uA74C\uA74E\uA750\uA752\uA754\uA756\uA758\uA75A\uA75C\uA75E\uA760\uA762\uA764\uA766\uA768\uA76A\uA76C\uA76E\uA779\uA77B\uA77D-\uA77E\uA780\uA782\uA784\uA786\uA78B\uA78D\uA790\uA792\uA796\uA798\uA79A\uA79C\uA79E\uA7A0\uA7A2\uA7A4\uA7A6\uA7A8\uA7AA-\uA7AD\uA7B0-\uA7B4\uA7B6\uFF21-\uFF3A]/;
-  var peg$c154 = peg$classExpectation([["A", "Z"], ["\xC0", "\xD6"], ["\xD8", "\xDE"], "\u0100", "\u0102", "\u0104", "\u0106", "\u0108", "\u010A", "\u010C", "\u010E", "\u0110", "\u0112", "\u0114", "\u0116", "\u0118", "\u011A", "\u011C", "\u011E", "\u0120", "\u0122", "\u0124", "\u0126", "\u0128", "\u012A", "\u012C", "\u012E", "\u0130", "\u0132", "\u0134", "\u0136", "\u0139", "\u013B", "\u013D", "\u013F", "\u0141", "\u0143", "\u0145", "\u0147", "\u014A", "\u014C", "\u014E", "\u0150", "\u0152", "\u0154", "\u0156", "\u0158", "\u015A", "\u015C", "\u015E", "\u0160", "\u0162", "\u0164", "\u0166", "\u0168", "\u016A", "\u016C", "\u016E", "\u0170", "\u0172", "\u0174", "\u0176", ["\u0178", "\u0179"], "\u017B", "\u017D", ["\u0181", "\u0182"], "\u0184", ["\u0186", "\u0187"], ["\u0189", "\u018B"], ["\u018E", "\u0191"], ["\u0193", "\u0194"], ["\u0196", "\u0198"], ["\u019C", "\u019D"], ["\u019F", "\u01A0"], "\u01A2", "\u01A4", ["\u01A6", "\u01A7"], "\u01A9", "\u01AC", ["\u01AE", "\u01AF"], ["\u01B1", "\u01B3"], "\u01B5", ["\u01B7", "\u01B8"], "\u01BC", "\u01C4", "\u01C7", "\u01CA", "\u01CD", "\u01CF", "\u01D1", "\u01D3", "\u01D5", "\u01D7", "\u01D9", "\u01DB", "\u01DE", "\u01E0", "\u01E2", "\u01E4", "\u01E6", "\u01E8", "\u01EA", "\u01EC", "\u01EE", "\u01F1", "\u01F4", ["\u01F6", "\u01F8"], "\u01FA", "\u01FC", "\u01FE", "\u0200", "\u0202", "\u0204", "\u0206", "\u0208", "\u020A", "\u020C", "\u020E", "\u0210", "\u0212", "\u0214", "\u0216", "\u0218", "\u021A", "\u021C", "\u021E", "\u0220", "\u0222", "\u0224", "\u0226", "\u0228", "\u022A", "\u022C", "\u022E", "\u0230", "\u0232", ["\u023A", "\u023B"], ["\u023D", "\u023E"], "\u0241", ["\u0243", "\u0246"], "\u0248", "\u024A", "\u024C", "\u024E", "\u0370", "\u0372", "\u0376", "\u037F", "\u0386", ["\u0388", "\u038A"], "\u038C", ["\u038E", "\u038F"], ["\u0391", "\u03A1"], ["\u03A3", "\u03AB"], "\u03CF", ["\u03D2", "\u03D4"], "\u03D8", "\u03DA", "\u03DC", "\u03DE", "\u03E0", "\u03E2", "\u03E4", "\u03E6", "\u03E8", "\u03EA", "\u03EC", "\u03EE", "\u03F4", "\u03F7", ["\u03F9", "\u03FA"], ["\u03FD", "\u042F"], "\u0460", "\u0462", "\u0464", "\u0466", "\u0468", "\u046A", "\u046C", "\u046E", "\u0470", "\u0472", "\u0474", "\u0476", "\u0478", "\u047A", "\u047C", "\u047E", "\u0480", "\u048A", "\u048C", "\u048E", "\u0490", "\u0492", "\u0494", "\u0496", "\u0498", "\u049A", "\u049C", "\u049E", "\u04A0", "\u04A2", "\u04A4", "\u04A6", "\u04A8", "\u04AA", "\u04AC", "\u04AE", "\u04B0", "\u04B2", "\u04B4", "\u04B6", "\u04B8", "\u04BA", "\u04BC", "\u04BE", ["\u04C0", "\u04C1"], "\u04C3", "\u04C5", "\u04C7", "\u04C9", "\u04CB", "\u04CD", "\u04D0", "\u04D2", "\u04D4", "\u04D6", "\u04D8", "\u04DA", "\u04DC", "\u04DE", "\u04E0", "\u04E2", "\u04E4", "\u04E6", "\u04E8", "\u04EA", "\u04EC", "\u04EE", "\u04F0", "\u04F2", "\u04F4", "\u04F6", "\u04F8", "\u04FA", "\u04FC", "\u04FE", "\u0500", "\u0502", "\u0504", "\u0506", "\u0508", "\u050A", "\u050C", "\u050E", "\u0510", "\u0512", "\u0514", "\u0516", "\u0518", "\u051A", "\u051C", "\u051E", "\u0520", "\u0522", "\u0524", "\u0526", "\u0528", "\u052A", "\u052C", "\u052E", ["\u0531", "\u0556"], ["\u10A0", "\u10C5"], "\u10C7", "\u10CD", ["\u13A0", "\u13F5"], "\u1E00", "\u1E02", "\u1E04", "\u1E06", "\u1E08", "\u1E0A", "\u1E0C", "\u1E0E", "\u1E10", "\u1E12", "\u1E14", "\u1E16", "\u1E18", "\u1E1A", "\u1E1C", "\u1E1E", "\u1E20", "\u1E22", "\u1E24", "\u1E26", "\u1E28", "\u1E2A", "\u1E2C", "\u1E2E", "\u1E30", "\u1E32", "\u1E34", "\u1E36", "\u1E38", "\u1E3A", "\u1E3C", "\u1E3E", "\u1E40", "\u1E42", "\u1E44", "\u1E46", "\u1E48", "\u1E4A", "\u1E4C", "\u1E4E", "\u1E50", "\u1E52", "\u1E54", "\u1E56", "\u1E58", "\u1E5A", "\u1E5C", "\u1E5E", "\u1E60", "\u1E62", "\u1E64", "\u1E66", "\u1E68", "\u1E6A", "\u1E6C", "\u1E6E", "\u1E70", "\u1E72", "\u1E74", "\u1E76", "\u1E78", "\u1E7A", "\u1E7C", "\u1E7E", "\u1E80", "\u1E82", "\u1E84", "\u1E86", "\u1E88", "\u1E8A", "\u1E8C", "\u1E8E", "\u1E90", "\u1E92", "\u1E94", "\u1E9E", "\u1EA0", "\u1EA2", "\u1EA4", "\u1EA6", "\u1EA8", "\u1EAA", "\u1EAC", "\u1EAE", "\u1EB0", "\u1EB2", "\u1EB4", "\u1EB6", "\u1EB8", "\u1EBA", "\u1EBC", "\u1EBE", "\u1EC0", "\u1EC2", "\u1EC4", "\u1EC6", "\u1EC8", "\u1ECA", "\u1ECC", "\u1ECE", "\u1ED0", "\u1ED2", "\u1ED4", "\u1ED6", "\u1ED8", "\u1EDA", "\u1EDC", "\u1EDE", "\u1EE0", "\u1EE2", "\u1EE4", "\u1EE6", "\u1EE8", "\u1EEA", "\u1EEC", "\u1EEE", "\u1EF0", "\u1EF2", "\u1EF4", "\u1EF6", "\u1EF8", "\u1EFA", "\u1EFC", "\u1EFE", ["\u1F08", "\u1F0F"], ["\u1F18", "\u1F1D"], ["\u1F28", "\u1F2F"], ["\u1F38", "\u1F3F"], ["\u1F48", "\u1F4D"], "\u1F59", "\u1F5B", "\u1F5D", "\u1F5F", ["\u1F68", "\u1F6F"], ["\u1FB8", "\u1FBB"], ["\u1FC8", "\u1FCB"], ["\u1FD8", "\u1FDB"], ["\u1FE8", "\u1FEC"], ["\u1FF8", "\u1FFB"], "\u2102", "\u2107", ["\u210B", "\u210D"], ["\u2110", "\u2112"], "\u2115", ["\u2119", "\u211D"], "\u2124", "\u2126", "\u2128", ["\u212A", "\u212D"], ["\u2130", "\u2133"], ["\u213E", "\u213F"], "\u2145", "\u2183", ["\u2C00", "\u2C2E"], "\u2C60", ["\u2C62", "\u2C64"], "\u2C67", "\u2C69", "\u2C6B", ["\u2C6D", "\u2C70"], "\u2C72", "\u2C75", ["\u2C7E", "\u2C80"], "\u2C82", "\u2C84", "\u2C86", "\u2C88", "\u2C8A", "\u2C8C", "\u2C8E", "\u2C90", "\u2C92", "\u2C94", "\u2C96", "\u2C98", "\u2C9A", "\u2C9C", "\u2C9E", "\u2CA0", "\u2CA2", "\u2CA4", "\u2CA6", "\u2CA8", "\u2CAA", "\u2CAC", "\u2CAE", "\u2CB0", "\u2CB2", "\u2CB4", "\u2CB6", "\u2CB8", "\u2CBA", "\u2CBC", "\u2CBE", "\u2CC0", "\u2CC2", "\u2CC4", "\u2CC6", "\u2CC8", "\u2CCA", "\u2CCC", "\u2CCE", "\u2CD0", "\u2CD2", "\u2CD4", "\u2CD6", "\u2CD8", "\u2CDA", "\u2CDC", "\u2CDE", "\u2CE0", "\u2CE2", "\u2CEB", "\u2CED", "\u2CF2", "\uA640", "\uA642", "\uA644", "\uA646", "\uA648", "\uA64A", "\uA64C", "\uA64E", "\uA650", "\uA652", "\uA654", "\uA656", "\uA658", "\uA65A", "\uA65C", "\uA65E", "\uA660", "\uA662", "\uA664", "\uA666", "\uA668", "\uA66A", "\uA66C", "\uA680", "\uA682", "\uA684", "\uA686", "\uA688", "\uA68A", "\uA68C", "\uA68E", "\uA690", "\uA692", "\uA694", "\uA696", "\uA698", "\uA69A", "\uA722", "\uA724", "\uA726", "\uA728", "\uA72A", "\uA72C", "\uA72E", "\uA732", "\uA734", "\uA736", "\uA738", "\uA73A", "\uA73C", "\uA73E", "\uA740", "\uA742", "\uA744", "\uA746", "\uA748", "\uA74A", "\uA74C", "\uA74E", "\uA750", "\uA752", "\uA754", "\uA756", "\uA758", "\uA75A", "\uA75C", "\uA75E", "\uA760", "\uA762", "\uA764", "\uA766", "\uA768", "\uA76A", "\uA76C", "\uA76E", "\uA779", "\uA77B", ["\uA77D", "\uA77E"], "\uA780", "\uA782", "\uA784", "\uA786", "\uA78B", "\uA78D", "\uA790", "\uA792", "\uA796", "\uA798", "\uA79A", "\uA79C", "\uA79E", "\uA7A0", "\uA7A2", "\uA7A4", "\uA7A6", "\uA7A8", ["\uA7AA", "\uA7AD"], ["\uA7B0", "\uA7B4"], "\uA7B6", ["\uFF21", "\uFF3A"]], false, false);
-  var peg$c155 = /^[\u0903\u093B\u093E-\u0940\u0949-\u094C\u094E-\u094F\u0982-\u0983\u09BE-\u09C0\u09C7-\u09C8\u09CB-\u09CC\u09D7\u0A03\u0A3E-\u0A40\u0A83\u0ABE-\u0AC0\u0AC9\u0ACB-\u0ACC\u0B02-\u0B03\u0B3E\u0B40\u0B47-\u0B48\u0B4B-\u0B4C\u0B57\u0BBE-\u0BBF\u0BC1-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCC\u0BD7\u0C01-\u0C03\u0C41-\u0C44\u0C82-\u0C83\u0CBE\u0CC0-\u0CC4\u0CC7-\u0CC8\u0CCA-\u0CCB\u0CD5-\u0CD6\u0D02-\u0D03\u0D3E-\u0D40\u0D46-\u0D48\u0D4A-\u0D4C\u0D57\u0D82-\u0D83\u0DCF-\u0DD1\u0DD8-\u0DDF\u0DF2-\u0DF3\u0F3E-\u0F3F\u0F7F\u102B-\u102C\u1031\u1038\u103B-\u103C\u1056-\u1057\u1062-\u1064\u1067-\u106D\u1083-\u1084\u1087-\u108C\u108F\u109A-\u109C\u17B6\u17BE-\u17C5\u17C7-\u17C8\u1923-\u1926\u1929-\u192B\u1930-\u1931\u1933-\u1938\u1A19-\u1A1A\u1A55\u1A57\u1A61\u1A63-\u1A64\u1A6D-\u1A72\u1B04\u1B35\u1B3B\u1B3D-\u1B41\u1B43-\u1B44\u1B82\u1BA1\u1BA6-\u1BA7\u1BAA\u1BE7\u1BEA-\u1BEC\u1BEE\u1BF2-\u1BF3\u1C24-\u1C2B\u1C34-\u1C35\u1CE1\u1CF2-\u1CF3\u302E-\u302F\uA823-\uA824\uA827\uA880-\uA881\uA8B4-\uA8C3\uA952-\uA953\uA983\uA9B4-\uA9B5\uA9BA-\uA9BB\uA9BD-\uA9C0\uAA2F-\uAA30\uAA33-\uAA34\uAA4D\uAA7B\uAA7D\uAAEB\uAAEE-\uAAEF\uAAF5\uABE3-\uABE4\uABE6-\uABE7\uABE9-\uABEA\uABEC]/;
-  var peg$c156 = peg$classExpectation(["\u0903", "\u093B", ["\u093E", "\u0940"], ["\u0949", "\u094C"], ["\u094E", "\u094F"], ["\u0982", "\u0983"], ["\u09BE", "\u09C0"], ["\u09C7", "\u09C8"], ["\u09CB", "\u09CC"], "\u09D7", "\u0A03", ["\u0A3E", "\u0A40"], "\u0A83", ["\u0ABE", "\u0AC0"], "\u0AC9", ["\u0ACB", "\u0ACC"], ["\u0B02", "\u0B03"], "\u0B3E", "\u0B40", ["\u0B47", "\u0B48"], ["\u0B4B", "\u0B4C"], "\u0B57", ["\u0BBE", "\u0BBF"], ["\u0BC1", "\u0BC2"], ["\u0BC6", "\u0BC8"], ["\u0BCA", "\u0BCC"], "\u0BD7", ["\u0C01", "\u0C03"], ["\u0C41", "\u0C44"], ["\u0C82", "\u0C83"], "\u0CBE", ["\u0CC0", "\u0CC4"], ["\u0CC7", "\u0CC8"], ["\u0CCA", "\u0CCB"], ["\u0CD5", "\u0CD6"], ["\u0D02", "\u0D03"], ["\u0D3E", "\u0D40"], ["\u0D46", "\u0D48"], ["\u0D4A", "\u0D4C"], "\u0D57", ["\u0D82", "\u0D83"], ["\u0DCF", "\u0DD1"], ["\u0DD8", "\u0DDF"], ["\u0DF2", "\u0DF3"], ["\u0F3E", "\u0F3F"], "\u0F7F", ["\u102B", "\u102C"], "\u1031", "\u1038", ["\u103B", "\u103C"], ["\u1056", "\u1057"], ["\u1062", "\u1064"], ["\u1067", "\u106D"], ["\u1083", "\u1084"], ["\u1087", "\u108C"], "\u108F", ["\u109A", "\u109C"], "\u17B6", ["\u17BE", "\u17C5"], ["\u17C7", "\u17C8"], ["\u1923", "\u1926"], ["\u1929", "\u192B"], ["\u1930", "\u1931"], ["\u1933", "\u1938"], ["\u1A19", "\u1A1A"], "\u1A55", "\u1A57", "\u1A61", ["\u1A63", "\u1A64"], ["\u1A6D", "\u1A72"], "\u1B04", "\u1B35", "\u1B3B", ["\u1B3D", "\u1B41"], ["\u1B43", "\u1B44"], "\u1B82", "\u1BA1", ["\u1BA6", "\u1BA7"], "\u1BAA", "\u1BE7", ["\u1BEA", "\u1BEC"], "\u1BEE", ["\u1BF2", "\u1BF3"], ["\u1C24", "\u1C2B"], ["\u1C34", "\u1C35"], "\u1CE1", ["\u1CF2", "\u1CF3"], ["\u302E", "\u302F"], ["\uA823", "\uA824"], "\uA827", ["\uA880", "\uA881"], ["\uA8B4", "\uA8C3"], ["\uA952", "\uA953"], "\uA983", ["\uA9B4", "\uA9B5"], ["\uA9BA", "\uA9BB"], ["\uA9BD", "\uA9C0"], ["\uAA2F", "\uAA30"], ["\uAA33", "\uAA34"], "\uAA4D", "\uAA7B", "\uAA7D", "\uAAEB", ["\uAAEE", "\uAAEF"], "\uAAF5", ["\uABE3", "\uABE4"], ["\uABE6", "\uABE7"], ["\uABE9", "\uABEA"], "\uABEC"], false, false);
-  var peg$c157 = /^[\u0300-\u036F\u0483-\u0487\u0591-\u05BD\u05BF\u05C1-\u05C2\u05C4-\u05C5\u05C7\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7-\u06E8\u06EA-\u06ED\u0711\u0730-\u074A\u07A6-\u07B0\u07EB-\u07F3\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u08E3-\u0902\u093A\u093C\u0941-\u0948\u094D\u0951-\u0957\u0962-\u0963\u0981\u09BC\u09C1-\u09C4\u09CD\u09E2-\u09E3\u0A01-\u0A02\u0A3C\u0A41-\u0A42\u0A47-\u0A48\u0A4B-\u0A4D\u0A51\u0A70-\u0A71\u0A75\u0A81-\u0A82\u0ABC\u0AC1-\u0AC5\u0AC7-\u0AC8\u0ACD\u0AE2-\u0AE3\u0B01\u0B3C\u0B3F\u0B41-\u0B44\u0B4D\u0B56\u0B62-\u0B63\u0B82\u0BC0\u0BCD\u0C00\u0C3E-\u0C40\u0C46-\u0C48\u0C4A-\u0C4D\u0C55-\u0C56\u0C62-\u0C63\u0C81\u0CBC\u0CBF\u0CC6\u0CCC-\u0CCD\u0CE2-\u0CE3\u0D01\u0D41-\u0D44\u0D4D\u0D62-\u0D63\u0DCA\u0DD2-\u0DD4\u0DD6\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0EB1\u0EB4-\u0EB9\u0EBB-\u0EBC\u0EC8-\u0ECD\u0F18-\u0F19\u0F35\u0F37\u0F39\u0F71-\u0F7E\u0F80-\u0F84\u0F86-\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102D-\u1030\u1032-\u1037\u1039-\u103A\u103D-\u103E\u1058-\u1059\u105E-\u1060\u1071-\u1074\u1082\u1085-\u1086\u108D\u109D\u135D-\u135F\u1712-\u1714\u1732-\u1734\u1752-\u1753\u1772-\u1773\u17B4-\u17B5\u17B7-\u17BD\u17C6\u17C9-\u17D3\u17DD\u180B-\u180D\u18A9\u1920-\u1922\u1927-\u1928\u1932\u1939-\u193B\u1A17-\u1A18\u1A1B\u1A56\u1A58-\u1A5E\u1A60\u1A62\u1A65-\u1A6C\u1A73-\u1A7C\u1A7F\u1AB0-\u1ABD\u1B00-\u1B03\u1B34\u1B36-\u1B3A\u1B3C\u1B42\u1B6B-\u1B73\u1B80-\u1B81\u1BA2-\u1BA5\u1BA8-\u1BA9\u1BAB-\u1BAD\u1BE6\u1BE8-\u1BE9\u1BED\u1BEF-\u1BF1\u1C2C-\u1C33\u1C36-\u1C37\u1CD0-\u1CD2\u1CD4-\u1CE0\u1CE2-\u1CE8\u1CED\u1CF4\u1CF8-\u1CF9\u1DC0-\u1DF5\u1DFC-\u1DFF\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302D\u3099-\u309A\uA66F\uA674-\uA67D\uA69E-\uA69F\uA6F0-\uA6F1\uA802\uA806\uA80B\uA825-\uA826\uA8C4\uA8E0-\uA8F1\uA926-\uA92D\uA947-\uA951\uA980-\uA982\uA9B3\uA9B6-\uA9B9\uA9BC\uA9E5\uAA29-\uAA2E\uAA31-\uAA32\uAA35-\uAA36\uAA43\uAA4C\uAA7C\uAAB0\uAAB2-\uAAB4\uAAB7-\uAAB8\uAABE-\uAABF\uAAC1\uAAEC-\uAAED\uAAF6\uABE5\uABE8\uABED\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F]/;
-  var peg$c158 = peg$classExpectation([["\u0300", "\u036F"], ["\u0483", "\u0487"], ["\u0591", "\u05BD"], "\u05BF", ["\u05C1", "\u05C2"], ["\u05C4", "\u05C5"], "\u05C7", ["\u0610", "\u061A"], ["\u064B", "\u065F"], "\u0670", ["\u06D6", "\u06DC"], ["\u06DF", "\u06E4"], ["\u06E7", "\u06E8"], ["\u06EA", "\u06ED"], "\u0711", ["\u0730", "\u074A"], ["\u07A6", "\u07B0"], ["\u07EB", "\u07F3"], ["\u0816", "\u0819"], ["\u081B", "\u0823"], ["\u0825", "\u0827"], ["\u0829", "\u082D"], ["\u0859", "\u085B"], ["\u08E3", "\u0902"], "\u093A", "\u093C", ["\u0941", "\u0948"], "\u094D", ["\u0951", "\u0957"], ["\u0962", "\u0963"], "\u0981", "\u09BC", ["\u09C1", "\u09C4"], "\u09CD", ["\u09E2", "\u09E3"], ["\u0A01", "\u0A02"], "\u0A3C", ["\u0A41", "\u0A42"], ["\u0A47", "\u0A48"], ["\u0A4B", "\u0A4D"], "\u0A51", ["\u0A70", "\u0A71"], "\u0A75", ["\u0A81", "\u0A82"], "\u0ABC", ["\u0AC1", "\u0AC5"], ["\u0AC7", "\u0AC8"], "\u0ACD", ["\u0AE2", "\u0AE3"], "\u0B01", "\u0B3C", "\u0B3F", ["\u0B41", "\u0B44"], "\u0B4D", "\u0B56", ["\u0B62", "\u0B63"], "\u0B82", "\u0BC0", "\u0BCD", "\u0C00", ["\u0C3E", "\u0C40"], ["\u0C46", "\u0C48"], ["\u0C4A", "\u0C4D"], ["\u0C55", "\u0C56"], ["\u0C62", "\u0C63"], "\u0C81", "\u0CBC", "\u0CBF", "\u0CC6", ["\u0CCC", "\u0CCD"], ["\u0CE2", "\u0CE3"], "\u0D01", ["\u0D41", "\u0D44"], "\u0D4D", ["\u0D62", "\u0D63"], "\u0DCA", ["\u0DD2", "\u0DD4"], "\u0DD6", "\u0E31", ["\u0E34", "\u0E3A"], ["\u0E47", "\u0E4E"], "\u0EB1", ["\u0EB4", "\u0EB9"], ["\u0EBB", "\u0EBC"], ["\u0EC8", "\u0ECD"], ["\u0F18", "\u0F19"], "\u0F35", "\u0F37", "\u0F39", ["\u0F71", "\u0F7E"], ["\u0F80", "\u0F84"], ["\u0F86", "\u0F87"], ["\u0F8D", "\u0F97"], ["\u0F99", "\u0FBC"], "\u0FC6", ["\u102D", "\u1030"], ["\u1032", "\u1037"], ["\u1039", "\u103A"], ["\u103D", "\u103E"], ["\u1058", "\u1059"], ["\u105E", "\u1060"], ["\u1071", "\u1074"], "\u1082", ["\u1085", "\u1086"], "\u108D", "\u109D", ["\u135D", "\u135F"], ["\u1712", "\u1714"], ["\u1732", "\u1734"], ["\u1752", "\u1753"], ["\u1772", "\u1773"], ["\u17B4", "\u17B5"], ["\u17B7", "\u17BD"], "\u17C6", ["\u17C9", "\u17D3"], "\u17DD", ["\u180B", "\u180D"], "\u18A9", ["\u1920", "\u1922"], ["\u1927", "\u1928"], "\u1932", ["\u1939", "\u193B"], ["\u1A17", "\u1A18"], "\u1A1B", "\u1A56", ["\u1A58", "\u1A5E"], "\u1A60", "\u1A62", ["\u1A65", "\u1A6C"], ["\u1A73", "\u1A7C"], "\u1A7F", ["\u1AB0", "\u1ABD"], ["\u1B00", "\u1B03"], "\u1B34", ["\u1B36", "\u1B3A"], "\u1B3C", "\u1B42", ["\u1B6B", "\u1B73"], ["\u1B80", "\u1B81"], ["\u1BA2", "\u1BA5"], ["\u1BA8", "\u1BA9"], ["\u1BAB", "\u1BAD"], "\u1BE6", ["\u1BE8", "\u1BE9"], "\u1BED", ["\u1BEF", "\u1BF1"], ["\u1C2C", "\u1C33"], ["\u1C36", "\u1C37"], ["\u1CD0", "\u1CD2"], ["\u1CD4", "\u1CE0"], ["\u1CE2", "\u1CE8"], "\u1CED", "\u1CF4", ["\u1CF8", "\u1CF9"], ["\u1DC0", "\u1DF5"], ["\u1DFC", "\u1DFF"], ["\u20D0", "\u20DC"], "\u20E1", ["\u20E5", "\u20F0"], ["\u2CEF", "\u2CF1"], "\u2D7F", ["\u2DE0", "\u2DFF"], ["\u302A", "\u302D"], ["\u3099", "\u309A"], "\uA66F", ["\uA674", "\uA67D"], ["\uA69E", "\uA69F"], ["\uA6F0", "\uA6F1"], "\uA802", "\uA806", "\uA80B", ["\uA825", "\uA826"], "\uA8C4", ["\uA8E0", "\uA8F1"], ["\uA926", "\uA92D"], ["\uA947", "\uA951"], ["\uA980", "\uA982"], "\uA9B3", ["\uA9B6", "\uA9B9"], "\uA9BC", "\uA9E5", ["\uAA29", "\uAA2E"], ["\uAA31", "\uAA32"], ["\uAA35", "\uAA36"], "\uAA43", "\uAA4C", "\uAA7C", "\uAAB0", ["\uAAB2", "\uAAB4"], ["\uAAB7", "\uAAB8"], ["\uAABE", "\uAABF"], "\uAAC1", ["\uAAEC", "\uAAED"], "\uAAF6", "\uABE5", "\uABE8", "\uABED", "\uFB1E", ["\uFE00", "\uFE0F"], ["\uFE20", "\uFE2F"]], false, false);
-  var peg$c159 = /^[0-9\u0660-\u0669\u06F0-\u06F9\u07C0-\u07C9\u0966-\u096F\u09E6-\u09EF\u0A66-\u0A6F\u0AE6-\u0AEF\u0B66-\u0B6F\u0BE6-\u0BEF\u0C66-\u0C6F\u0CE6-\u0CEF\u0D66-\u0D6F\u0DE6-\u0DEF\u0E50-\u0E59\u0ED0-\u0ED9\u0F20-\u0F29\u1040-\u1049\u1090-\u1099\u17E0-\u17E9\u1810-\u1819\u1946-\u194F\u19D0-\u19D9\u1A80-\u1A89\u1A90-\u1A99\u1B50-\u1B59\u1BB0-\u1BB9\u1C40-\u1C49\u1C50-\u1C59\uA620-\uA629\uA8D0-\uA8D9\uA900-\uA909\uA9D0-\uA9D9\uA9F0-\uA9F9\uAA50-\uAA59\uABF0-\uABF9\uFF10-\uFF19]/;
-  var peg$c160 = peg$classExpectation([["0", "9"], ["\u0660", "\u0669"], ["\u06F0", "\u06F9"], ["\u07C0", "\u07C9"], ["\u0966", "\u096F"], ["\u09E6", "\u09EF"], ["\u0A66", "\u0A6F"], ["\u0AE6", "\u0AEF"], ["\u0B66", "\u0B6F"], ["\u0BE6", "\u0BEF"], ["\u0C66", "\u0C6F"], ["\u0CE6", "\u0CEF"], ["\u0D66", "\u0D6F"], ["\u0DE6", "\u0DEF"], ["\u0E50", "\u0E59"], ["\u0ED0", "\u0ED9"], ["\u0F20", "\u0F29"], ["\u1040", "\u1049"], ["\u1090", "\u1099"], ["\u17E0", "\u17E9"], ["\u1810", "\u1819"], ["\u1946", "\u194F"], ["\u19D0", "\u19D9"], ["\u1A80", "\u1A89"], ["\u1A90", "\u1A99"], ["\u1B50", "\u1B59"], ["\u1BB0", "\u1BB9"], ["\u1C40", "\u1C49"], ["\u1C50", "\u1C59"], ["\uA620", "\uA629"], ["\uA8D0", "\uA8D9"], ["\uA900", "\uA909"], ["\uA9D0", "\uA9D9"], ["\uA9F0", "\uA9F9"], ["\uAA50", "\uAA59"], ["\uABF0", "\uABF9"], ["\uFF10", "\uFF19"]], false, false);
-  var peg$c161 = /^[\u16EE-\u16F0\u2160-\u2182\u2185-\u2188\u3007\u3021-\u3029\u3038-\u303A\uA6E6-\uA6EF]/;
-  var peg$c162 = peg$classExpectation([["\u16EE", "\u16F0"], ["\u2160", "\u2182"], ["\u2185", "\u2188"], "\u3007", ["\u3021", "\u3029"], ["\u3038", "\u303A"], ["\uA6E6", "\uA6EF"]], false, false);
-  var peg$c163 = /^[_\u203F-\u2040\u2054\uFE33-\uFE34\uFE4D-\uFE4F\uFF3F]/;
-  var peg$c164 = peg$classExpectation(["_", ["\u203F", "\u2040"], "\u2054", ["\uFE33", "\uFE34"], ["\uFE4D", "\uFE4F"], "\uFF3F"], false, false);
-  var peg$c165 = /^[ \xA0\u1680\u2000-\u200A\u202F\u205F\u3000]/;
-  var peg$c166 = peg$classExpectation([" ", "\xA0", "\u1680", ["\u2000", "\u200A"], "\u202F", "\u205F", "\u3000"], false, false);
-  var peg$c167 = "break";
-  var peg$c168 = peg$literalExpectation("break", false);
-  var peg$c169 = "case";
-  var peg$c170 = peg$literalExpectation("case", false);
-  var peg$c171 = "catch";
-  var peg$c172 = peg$literalExpectation("catch", false);
-  var peg$c173 = "class";
-  var peg$c174 = peg$literalExpectation("class", false);
-  var peg$c175 = "const";
-  var peg$c176 = peg$literalExpectation("const", false);
-  var peg$c177 = "continue";
-  var peg$c178 = peg$literalExpectation("continue", false);
-  var peg$c179 = "debugger";
-  var peg$c180 = peg$literalExpectation("debugger", false);
-  var peg$c181 = "default";
-  var peg$c182 = peg$literalExpectation("default", false);
-  var peg$c183 = "delete";
-  var peg$c184 = peg$literalExpectation("delete", false);
-  var peg$c185 = "do";
-  var peg$c186 = peg$literalExpectation("do", false);
-  var peg$c187 = "else";
-  var peg$c188 = peg$literalExpectation("else", false);
-  var peg$c189 = "enum";
-  var peg$c190 = peg$literalExpectation("enum", false);
-  var peg$c191 = "export";
-  var peg$c192 = peg$literalExpectation("export", false);
-  var peg$c193 = "extends";
-  var peg$c194 = peg$literalExpectation("extends", false);
-  var peg$c195 = "false";
-  var peg$c196 = peg$literalExpectation("false", false);
-  var peg$c197 = "finally";
-  var peg$c198 = peg$literalExpectation("finally", false);
-  var peg$c199 = "for";
-  var peg$c200 = peg$literalExpectation("for", false);
-  var peg$c201 = "function";
-  var peg$c202 = peg$literalExpectation("function", false);
-  var peg$c203 = "if";
-  var peg$c204 = peg$literalExpectation("if", false);
-  var peg$c205 = "import";
-  var peg$c206 = peg$literalExpectation("import", false);
-  var peg$c207 = "instanceof";
-  var peg$c208 = peg$literalExpectation("instanceof", false);
-  var peg$c209 = "in";
-  var peg$c210 = peg$literalExpectation("in", false);
-  var peg$c211 = "new";
-  var peg$c212 = peg$literalExpectation("new", false);
-  var peg$c213 = "null";
-  var peg$c214 = peg$literalExpectation("null", false);
-  var peg$c215 = "return";
-  var peg$c216 = peg$literalExpectation("return", false);
-  var peg$c217 = "super";
-  var peg$c218 = peg$literalExpectation("super", false);
-  var peg$c219 = "switch";
-  var peg$c220 = peg$literalExpectation("switch", false);
-  var peg$c221 = "this";
-  var peg$c222 = peg$literalExpectation("this", false);
-  var peg$c223 = "throw";
-  var peg$c224 = peg$literalExpectation("throw", false);
-  var peg$c225 = "true";
-  var peg$c226 = peg$literalExpectation("true", false);
-  var peg$c227 = "try";
-  var peg$c228 = peg$literalExpectation("try", false);
-  var peg$c229 = "typeof";
-  var peg$c230 = peg$literalExpectation("typeof", false);
-  var peg$c231 = "var";
-  var peg$c232 = peg$literalExpectation("var", false);
-  var peg$c233 = "void";
-  var peg$c234 = peg$literalExpectation("void", false);
-  var peg$c235 = "while";
-  var peg$c236 = peg$literalExpectation("while", false);
-  var peg$c237 = "with";
-  var peg$c238 = peg$literalExpectation("with", false);
-  var peg$c239 = ";";
-  var peg$c240 = peg$literalExpectation(";", false);
+  var peg$c102 = peg$literalExpectation("u", false);
+  var peg$c103 = /^[0-9]/;
+  var peg$c104 = /^[0-9a-f]/i;
+  var peg$c105 = peg$classExpectation([["0", "9"], ["a", "f"]], false, true);
+  var peg$c106 = ".";
+  var peg$c107 = peg$literalExpectation(".", false);
+  var peg$c108 = function() { return { type: "any", location: location() }; };
+  var peg$c109 = peg$otherExpectation("code block");
+  var peg$c110 = "{";
+  var peg$c111 = "}";
+  var peg$c112 = function(code) { return code; };
+  var peg$c113 = function() { error("Unbalanced brace."); };
+  var peg$c114 = /^[{}]/;
+  var peg$c115 = /^[a-z\xB5\xDF-\xF6\xF8-\xFF\u0101\u0103\u0105\u0107\u0109\u010B\u010D\u010F\u0111\u0113\u0115\u0117\u0119\u011B\u011D\u011F\u0121\u0123\u0125\u0127\u0129\u012B\u012D\u012F\u0131\u0133\u0135\u0137-\u0138\u013A\u013C\u013E\u0140\u0142\u0144\u0146\u0148-\u0149\u014B\u014D\u014F\u0151\u0153\u0155\u0157\u0159\u015B\u015D\u015F\u0161\u0163\u0165\u0167\u0169\u016B\u016D\u016F\u0171\u0173\u0175\u0177\u017A\u017C\u017E-\u0180\u0183\u0185\u0188\u018C-\u018D\u0192\u0195\u0199-\u019B\u019E\u01A1\u01A3\u01A5\u01A8\u01AA-\u01AB\u01AD\u01B0\u01B4\u01B6\u01B9-\u01BA\u01BD-\u01BF\u01C6\u01C9\u01CC\u01CE\u01D0\u01D2\u01D4\u01D6\u01D8\u01DA\u01DC-\u01DD\u01DF\u01E1\u01E3\u01E5\u01E7\u01E9\u01EB\u01ED\u01EF-\u01F0\u01F3\u01F5\u01F9\u01FB\u01FD\u01FF\u0201\u0203\u0205\u0207\u0209\u020B\u020D\u020F\u0211\u0213\u0215\u0217\u0219\u021B\u021D\u021F\u0221\u0223\u0225\u0227\u0229\u022B\u022D\u022F\u0231\u0233-\u0239\u023C\u023F-\u0240\u0242\u0247\u0249\u024B\u024D\u024F-\u0293\u0295-\u02AF\u0371\u0373\u0377\u037B-\u037D\u0390\u03AC-\u03CE\u03D0-\u03D1\u03D5-\u03D7\u03D9\u03DB\u03DD\u03DF\u03E1\u03E3\u03E5\u03E7\u03E9\u03EB\u03ED\u03EF-\u03F3\u03F5\u03F8\u03FB-\u03FC\u0430-\u045F\u0461\u0463\u0465\u0467\u0469\u046B\u046D\u046F\u0471\u0473\u0475\u0477\u0479\u047B\u047D\u047F\u0481\u048B\u048D\u048F\u0491\u0493\u0495\u0497\u0499\u049B\u049D\u049F\u04A1\u04A3\u04A5\u04A7\u04A9\u04AB\u04AD\u04AF\u04B1\u04B3\u04B5\u04B7\u04B9\u04BB\u04BD\u04BF\u04C2\u04C4\u04C6\u04C8\u04CA\u04CC\u04CE-\u04CF\u04D1\u04D3\u04D5\u04D7\u04D9\u04DB\u04DD\u04DF\u04E1\u04E3\u04E5\u04E7\u04E9\u04EB\u04ED\u04EF\u04F1\u04F3\u04F5\u04F7\u04F9\u04FB\u04FD\u04FF\u0501\u0503\u0505\u0507\u0509\u050B\u050D\u050F\u0511\u0513\u0515\u0517\u0519\u051B\u051D\u051F\u0521\u0523\u0525\u0527\u0529\u052B\u052D\u052F\u0561-\u0587\u13F8-\u13FD\u1D00-\u1D2B\u1D6B-\u1D77\u1D79-\u1D9A\u1E01\u1E03\u1E05\u1E07\u1E09\u1E0B\u1E0D\u1E0F\u1E11\u1E13\u1E15\u1E17\u1E19\u1E1B\u1E1D\u1E1F\u1E21\u1E23\u1E25\u1E27\u1E29\u1E2B\u1E2D\u1E2F\u1E31\u1E33\u1E35\u1E37\u1E39\u1E3B\u1E3D\u1E3F\u1E41\u1E43\u1E45\u1E47\u1E49\u1E4B\u1E4D\u1E4F\u1E51\u1E53\u1E55\u1E57\u1E59\u1E5B\u1E5D\u1E5F\u1E61\u1E63\u1E65\u1E67\u1E69\u1E6B\u1E6D\u1E6F\u1E71\u1E73\u1E75\u1E77\u1E79\u1E7B\u1E7D\u1E7F\u1E81\u1E83\u1E85\u1E87\u1E89\u1E8B\u1E8D\u1E8F\u1E91\u1E93\u1E95-\u1E9D\u1E9F\u1EA1\u1EA3\u1EA5\u1EA7\u1EA9\u1EAB\u1EAD\u1EAF\u1EB1\u1EB3\u1EB5\u1EB7\u1EB9\u1EBB\u1EBD\u1EBF\u1EC1\u1EC3\u1EC5\u1EC7\u1EC9\u1ECB\u1ECD\u1ECF\u1ED1\u1ED3\u1ED5\u1ED7\u1ED9\u1EDB\u1EDD\u1EDF\u1EE1\u1EE3\u1EE5\u1EE7\u1EE9\u1EEB\u1EED\u1EEF\u1EF1\u1EF3\u1EF5\u1EF7\u1EF9\u1EFB\u1EFD\u1EFF-\u1F07\u1F10-\u1F15\u1F20-\u1F27\u1F30-\u1F37\u1F40-\u1F45\u1F50-\u1F57\u1F60-\u1F67\u1F70-\u1F7D\u1F80-\u1F87\u1F90-\u1F97\u1FA0-\u1FA7\u1FB0-\u1FB4\u1FB6-\u1FB7\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FC7\u1FD0-\u1FD3\u1FD6-\u1FD7\u1FE0-\u1FE7\u1FF2-\u1FF4\u1FF6-\u1FF7\u210A\u210E-\u210F\u2113\u212F\u2134\u2139\u213C-\u213D\u2146-\u2149\u214E\u2184\u2C30-\u2C5E\u2C61\u2C65-\u2C66\u2C68\u2C6A\u2C6C\u2C71\u2C73-\u2C74\u2C76-\u2C7B\u2C81\u2C83\u2C85\u2C87\u2C89\u2C8B\u2C8D\u2C8F\u2C91\u2C93\u2C95\u2C97\u2C99\u2C9B\u2C9D\u2C9F\u2CA1\u2CA3\u2CA5\u2CA7\u2CA9\u2CAB\u2CAD\u2CAF\u2CB1\u2CB3\u2CB5\u2CB7\u2CB9\u2CBB\u2CBD\u2CBF\u2CC1\u2CC3\u2CC5\u2CC7\u2CC9\u2CCB\u2CCD\u2CCF\u2CD1\u2CD3\u2CD5\u2CD7\u2CD9\u2CDB\u2CDD\u2CDF\u2CE1\u2CE3-\u2CE4\u2CEC\u2CEE\u2CF3\u2D00-\u2D25\u2D27\u2D2D\uA641\uA643\uA645\uA647\uA649\uA64B\uA64D\uA64F\uA651\uA653\uA655\uA657\uA659\uA65B\uA65D\uA65F\uA661\uA663\uA665\uA667\uA669\uA66B\uA66D\uA681\uA683\uA685\uA687\uA689\uA68B\uA68D\uA68F\uA691\uA693\uA695\uA697\uA699\uA69B\uA723\uA725\uA727\uA729\uA72B\uA72D\uA72F-\uA731\uA733\uA735\uA737\uA739\uA73B\uA73D\uA73F\uA741\uA743\uA745\uA747\uA749\uA74B\uA74D\uA74F\uA751\uA753\uA755\uA757\uA759\uA75B\uA75D\uA75F\uA761\uA763\uA765\uA767\uA769\uA76B\uA76D\uA76F\uA771-\uA778\uA77A\uA77C\uA77F\uA781\uA783\uA785\uA787\uA78C\uA78E\uA791\uA793-\uA795\uA797\uA799\uA79B\uA79D\uA79F\uA7A1\uA7A3\uA7A5\uA7A7\uA7A9\uA7B5\uA7B7\uA7FA\uAB30-\uAB5A\uAB60-\uAB65\uAB70-\uABBF\uFB00-\uFB06\uFB13-\uFB17\uFF41-\uFF5A]/;
+  var peg$c116 = peg$classExpectation([["a", "z"], "\xB5", ["\xDF", "\xF6"], ["\xF8", "\xFF"], "\u0101", "\u0103", "\u0105", "\u0107", "\u0109", "\u010B", "\u010D", "\u010F", "\u0111", "\u0113", "\u0115", "\u0117", "\u0119", "\u011B", "\u011D", "\u011F", "\u0121", "\u0123", "\u0125", "\u0127", "\u0129", "\u012B", "\u012D", "\u012F", "\u0131", "\u0133", "\u0135", ["\u0137", "\u0138"], "\u013A", "\u013C", "\u013E", "\u0140", "\u0142", "\u0144", "\u0146", ["\u0148", "\u0149"], "\u014B", "\u014D", "\u014F", "\u0151", "\u0153", "\u0155", "\u0157", "\u0159", "\u015B", "\u015D", "\u015F", "\u0161", "\u0163", "\u0165", "\u0167", "\u0169", "\u016B", "\u016D", "\u016F", "\u0171", "\u0173", "\u0175", "\u0177", "\u017A", "\u017C", ["\u017E", "\u0180"], "\u0183", "\u0185", "\u0188", ["\u018C", "\u018D"], "\u0192", "\u0195", ["\u0199", "\u019B"], "\u019E", "\u01A1", "\u01A3", "\u01A5", "\u01A8", ["\u01AA", "\u01AB"], "\u01AD", "\u01B0", "\u01B4", "\u01B6", ["\u01B9", "\u01BA"], ["\u01BD", "\u01BF"], "\u01C6", "\u01C9", "\u01CC", "\u01CE", "\u01D0", "\u01D2", "\u01D4", "\u01D6", "\u01D8", "\u01DA", ["\u01DC", "\u01DD"], "\u01DF", "\u01E1", "\u01E3", "\u01E5", "\u01E7", "\u01E9", "\u01EB", "\u01ED", ["\u01EF", "\u01F0"], "\u01F3", "\u01F5", "\u01F9", "\u01FB", "\u01FD", "\u01FF", "\u0201", "\u0203", "\u0205", "\u0207", "\u0209", "\u020B", "\u020D", "\u020F", "\u0211", "\u0213", "\u0215", "\u0217", "\u0219", "\u021B", "\u021D", "\u021F", "\u0221", "\u0223", "\u0225", "\u0227", "\u0229", "\u022B", "\u022D", "\u022F", "\u0231", ["\u0233", "\u0239"], "\u023C", ["\u023F", "\u0240"], "\u0242", "\u0247", "\u0249", "\u024B", "\u024D", ["\u024F", "\u0293"], ["\u0295", "\u02AF"], "\u0371", "\u0373", "\u0377", ["\u037B", "\u037D"], "\u0390", ["\u03AC", "\u03CE"], ["\u03D0", "\u03D1"], ["\u03D5", "\u03D7"], "\u03D9", "\u03DB", "\u03DD", "\u03DF", "\u03E1", "\u03E3", "\u03E5", "\u03E7", "\u03E9", "\u03EB", "\u03ED", ["\u03EF", "\u03F3"], "\u03F5", "\u03F8", ["\u03FB", "\u03FC"], ["\u0430", "\u045F"], "\u0461", "\u0463", "\u0465", "\u0467", "\u0469", "\u046B", "\u046D", "\u046F", "\u0471", "\u0473", "\u0475", "\u0477", "\u0479", "\u047B", "\u047D", "\u047F", "\u0481", "\u048B", "\u048D", "\u048F", "\u0491", "\u0493", "\u0495", "\u0497", "\u0499", "\u049B", "\u049D", "\u049F", "\u04A1", "\u04A3", "\u04A5", "\u04A7", "\u04A9", "\u04AB", "\u04AD", "\u04AF", "\u04B1", "\u04B3", "\u04B5", "\u04B7", "\u04B9", "\u04BB", "\u04BD", "\u04BF", "\u04C2", "\u04C4", "\u04C6", "\u04C8", "\u04CA", "\u04CC", ["\u04CE", "\u04CF"], "\u04D1", "\u04D3", "\u04D5", "\u04D7", "\u04D9", "\u04DB", "\u04DD", "\u04DF", "\u04E1", "\u04E3", "\u04E5", "\u04E7", "\u04E9", "\u04EB", "\u04ED", "\u04EF", "\u04F1", "\u04F3", "\u04F5", "\u04F7", "\u04F9", "\u04FB", "\u04FD", "\u04FF", "\u0501", "\u0503", "\u0505", "\u0507", "\u0509", "\u050B", "\u050D", "\u050F", "\u0511", "\u0513", "\u0515", "\u0517", "\u0519", "\u051B", "\u051D", "\u051F", "\u0521", "\u0523", "\u0525", "\u0527", "\u0529", "\u052B", "\u052D", "\u052F", ["\u0561", "\u0587"], ["\u13F8", "\u13FD"], ["\u1D00", "\u1D2B"], ["\u1D6B", "\u1D77"], ["\u1D79", "\u1D9A"], "\u1E01", "\u1E03", "\u1E05", "\u1E07", "\u1E09", "\u1E0B", "\u1E0D", "\u1E0F", "\u1E11", "\u1E13", "\u1E15", "\u1E17", "\u1E19", "\u1E1B", "\u1E1D", "\u1E1F", "\u1E21", "\u1E23", "\u1E25", "\u1E27", "\u1E29", "\u1E2B", "\u1E2D", "\u1E2F", "\u1E31", "\u1E33", "\u1E35", "\u1E37", "\u1E39", "\u1E3B", "\u1E3D", "\u1E3F", "\u1E41", "\u1E43", "\u1E45", "\u1E47", "\u1E49", "\u1E4B", "\u1E4D", "\u1E4F", "\u1E51", "\u1E53", "\u1E55", "\u1E57", "\u1E59", "\u1E5B", "\u1E5D", "\u1E5F", "\u1E61", "\u1E63", "\u1E65", "\u1E67", "\u1E69", "\u1E6B", "\u1E6D", "\u1E6F", "\u1E71", "\u1E73", "\u1E75", "\u1E77", "\u1E79", "\u1E7B", "\u1E7D", "\u1E7F", "\u1E81", "\u1E83", "\u1E85", "\u1E87", "\u1E89", "\u1E8B", "\u1E8D", "\u1E8F", "\u1E91", "\u1E93", ["\u1E95", "\u1E9D"], "\u1E9F", "\u1EA1", "\u1EA3", "\u1EA5", "\u1EA7", "\u1EA9", "\u1EAB", "\u1EAD", "\u1EAF", "\u1EB1", "\u1EB3", "\u1EB5", "\u1EB7", "\u1EB9", "\u1EBB", "\u1EBD", "\u1EBF", "\u1EC1", "\u1EC3", "\u1EC5", "\u1EC7", "\u1EC9", "\u1ECB", "\u1ECD", "\u1ECF", "\u1ED1", "\u1ED3", "\u1ED5", "\u1ED7", "\u1ED9", "\u1EDB", "\u1EDD", "\u1EDF", "\u1EE1", "\u1EE3", "\u1EE5", "\u1EE7", "\u1EE9", "\u1EEB", "\u1EED", "\u1EEF", "\u1EF1", "\u1EF3", "\u1EF5", "\u1EF7", "\u1EF9", "\u1EFB", "\u1EFD", ["\u1EFF", "\u1F07"], ["\u1F10", "\u1F15"], ["\u1F20", "\u1F27"], ["\u1F30", "\u1F37"], ["\u1F40", "\u1F45"], ["\u1F50", "\u1F57"], ["\u1F60", "\u1F67"], ["\u1F70", "\u1F7D"], ["\u1F80", "\u1F87"], ["\u1F90", "\u1F97"], ["\u1FA0", "\u1FA7"], ["\u1FB0", "\u1FB4"], ["\u1FB6", "\u1FB7"], "\u1FBE", ["\u1FC2", "\u1FC4"], ["\u1FC6", "\u1FC7"], ["\u1FD0", "\u1FD3"], ["\u1FD6", "\u1FD7"], ["\u1FE0", "\u1FE7"], ["\u1FF2", "\u1FF4"], ["\u1FF6", "\u1FF7"], "\u210A", ["\u210E", "\u210F"], "\u2113", "\u212F", "\u2134", "\u2139", ["\u213C", "\u213D"], ["\u2146", "\u2149"], "\u214E", "\u2184", ["\u2C30", "\u2C5E"], "\u2C61", ["\u2C65", "\u2C66"], "\u2C68", "\u2C6A", "\u2C6C", "\u2C71", ["\u2C73", "\u2C74"], ["\u2C76", "\u2C7B"], "\u2C81", "\u2C83", "\u2C85", "\u2C87", "\u2C89", "\u2C8B", "\u2C8D", "\u2C8F", "\u2C91", "\u2C93", "\u2C95", "\u2C97", "\u2C99", "\u2C9B", "\u2C9D", "\u2C9F", "\u2CA1", "\u2CA3", "\u2CA5", "\u2CA7", "\u2CA9", "\u2CAB", "\u2CAD", "\u2CAF", "\u2CB1", "\u2CB3", "\u2CB5", "\u2CB7", "\u2CB9", "\u2CBB", "\u2CBD", "\u2CBF", "\u2CC1", "\u2CC3", "\u2CC5", "\u2CC7", "\u2CC9", "\u2CCB", "\u2CCD", "\u2CCF", "\u2CD1", "\u2CD3", "\u2CD5", "\u2CD7", "\u2CD9", "\u2CDB", "\u2CDD", "\u2CDF", "\u2CE1", ["\u2CE3", "\u2CE4"], "\u2CEC", "\u2CEE", "\u2CF3", ["\u2D00", "\u2D25"], "\u2D27", "\u2D2D", "\uA641", "\uA643", "\uA645", "\uA647", "\uA649", "\uA64B", "\uA64D", "\uA64F", "\uA651", "\uA653", "\uA655", "\uA657", "\uA659", "\uA65B", "\uA65D", "\uA65F", "\uA661", "\uA663", "\uA665", "\uA667", "\uA669", "\uA66B", "\uA66D", "\uA681", "\uA683", "\uA685", "\uA687", "\uA689", "\uA68B", "\uA68D", "\uA68F", "\uA691", "\uA693", "\uA695", "\uA697", "\uA699", "\uA69B", "\uA723", "\uA725", "\uA727", "\uA729", "\uA72B", "\uA72D", ["\uA72F", "\uA731"], "\uA733", "\uA735", "\uA737", "\uA739", "\uA73B", "\uA73D", "\uA73F", "\uA741", "\uA743", "\uA745", "\uA747", "\uA749", "\uA74B", "\uA74D", "\uA74F", "\uA751", "\uA753", "\uA755", "\uA757", "\uA759", "\uA75B", "\uA75D", "\uA75F", "\uA761", "\uA763", "\uA765", "\uA767", "\uA769", "\uA76B", "\uA76D", "\uA76F", ["\uA771", "\uA778"], "\uA77A", "\uA77C", "\uA77F", "\uA781", "\uA783", "\uA785", "\uA787", "\uA78C", "\uA78E", "\uA791", ["\uA793", "\uA795"], "\uA797", "\uA799", "\uA79B", "\uA79D", "\uA79F", "\uA7A1", "\uA7A3", "\uA7A5", "\uA7A7", "\uA7A9", "\uA7B5", "\uA7B7", "\uA7FA", ["\uAB30", "\uAB5A"], ["\uAB60", "\uAB65"], ["\uAB70", "\uABBF"], ["\uFB00", "\uFB06"], ["\uFB13", "\uFB17"], ["\uFF41", "\uFF5A"]], false, false);
+  var peg$c117 = /^[\u02B0-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0374\u037A\u0559\u0640\u06E5-\u06E6\u07F4-\u07F5\u07FA\u081A\u0824\u0828\u0971\u0E46\u0EC6\u10FC\u17D7\u1843\u1AA7\u1C78-\u1C7D\u1D2C-\u1D6A\u1D78\u1D9B-\u1DBF\u2071\u207F\u2090-\u209C\u2C7C-\u2C7D\u2D6F\u2E2F\u3005\u3031-\u3035\u303B\u309D-\u309E\u30FC-\u30FE\uA015\uA4F8-\uA4FD\uA60C\uA67F\uA69C-\uA69D\uA717-\uA71F\uA770\uA788\uA7F8-\uA7F9\uA9CF\uA9E6\uAA70\uAADD\uAAF3-\uAAF4\uAB5C-\uAB5F\uFF70\uFF9E-\uFF9F]/;
+  var peg$c118 = peg$classExpectation([["\u02B0", "\u02C1"], ["\u02C6", "\u02D1"], ["\u02E0", "\u02E4"], "\u02EC", "\u02EE", "\u0374", "\u037A", "\u0559", "\u0640", ["\u06E5", "\u06E6"], ["\u07F4", "\u07F5"], "\u07FA", "\u081A", "\u0824", "\u0828", "\u0971", "\u0E46", "\u0EC6", "\u10FC", "\u17D7", "\u1843", "\u1AA7", ["\u1C78", "\u1C7D"], ["\u1D2C", "\u1D6A"], "\u1D78", ["\u1D9B", "\u1DBF"], "\u2071", "\u207F", ["\u2090", "\u209C"], ["\u2C7C", "\u2C7D"], "\u2D6F", "\u2E2F", "\u3005", ["\u3031", "\u3035"], "\u303B", ["\u309D", "\u309E"], ["\u30FC", "\u30FE"], "\uA015", ["\uA4F8", "\uA4FD"], "\uA60C", "\uA67F", ["\uA69C", "\uA69D"], ["\uA717", "\uA71F"], "\uA770", "\uA788", ["\uA7F8", "\uA7F9"], "\uA9CF", "\uA9E6", "\uAA70", "\uAADD", ["\uAAF3", "\uAAF4"], ["\uAB5C", "\uAB5F"], "\uFF70", ["\uFF9E", "\uFF9F"]], false, false);
+  var peg$c119 = /^[\xAA\xBA\u01BB\u01C0-\u01C3\u0294\u05D0-\u05EA\u05F0-\u05F2\u0620-\u063F\u0641-\u064A\u066E-\u066F\u0671-\u06D3\u06D5\u06EE-\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u0800-\u0815\u0840-\u0858\u08A0-\u08B4\u0904-\u0939\u093D\u0950\u0958-\u0961\u0972-\u0980\u0985-\u098C\u098F-\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC-\u09DD\u09DF-\u09E1\u09F0-\u09F1\u0A05-\u0A0A\u0A0F-\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32-\u0A33\u0A35-\u0A36\u0A38-\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2-\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0-\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F-\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32-\u0B33\u0B35-\u0B39\u0B3D\u0B5C-\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99-\u0B9A\u0B9C\u0B9E-\u0B9F\u0BA3-\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C60-\u0C61\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0-\u0CE1\u0CF1-\u0CF2\u0D05-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32-\u0E33\u0E40-\u0E45\u0E81-\u0E82\u0E84\u0E87-\u0E88\u0E8A\u0E8D\u0E94-\u0E97\u0E99-\u0E9F\u0EA1-\u0EA3\u0EA5\u0EA7\u0EAA-\u0EAB\u0EAD-\u0EB0\u0EB2-\u0EB3\u0EBD\u0EC0-\u0EC4\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065-\u1066\u106E-\u1070\u1075-\u1081\u108E\u10D0-\u10FA\u10FD-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16F1-\u16F8\u1700-\u170C\u170E-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17DC\u1820-\u1842\u1844-\u1877\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1B05-\u1B33\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE-\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C77\u1CE9-\u1CEC\u1CEE-\u1CF1\u1CF5-\u1CF6\u2135-\u2138\u2D30-\u2D67\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3006\u303C\u3041-\u3096\u309F\u30A1-\u30FA\u30FF\u3105-\u312D\u3131-\u318E\u31A0-\u31BA\u31F0-\u31FF\u3400-\u4DB5\u4E00-\u9FD5\uA000-\uA014\uA016-\uA48C\uA4D0-\uA4F7\uA500-\uA60B\uA610-\uA61F\uA62A-\uA62B\uA66E\uA6A0-\uA6E5\uA78F\uA7F7\uA7FB-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9E0-\uA9E4\uA9E7-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA6F\uAA71-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5-\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADC\uAAE0-\uAAEA\uAAF2\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uABC0-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40-\uFB41\uFB43-\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF66-\uFF6F\uFF71-\uFF9D\uFFA0-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC]/;
+  var peg$c120 = peg$classExpectation(["\xAA", "\xBA", "\u01BB", ["\u01C0", "\u01C3"], "\u0294", ["\u05D0", "\u05EA"], ["\u05F0", "\u05F2"], ["\u0620", "\u063F"], ["\u0641", "\u064A"], ["\u066E", "\u066F"], ["\u0671", "\u06D3"], "\u06D5", ["\u06EE", "\u06EF"], ["\u06FA", "\u06FC"], "\u06FF", "\u0710", ["\u0712", "\u072F"], ["\u074D", "\u07A5"], "\u07B1", ["\u07CA", "\u07EA"], ["\u0800", "\u0815"], ["\u0840", "\u0858"], ["\u08A0", "\u08B4"], ["\u0904", "\u0939"], "\u093D", "\u0950", ["\u0958", "\u0961"], ["\u0972", "\u0980"], ["\u0985", "\u098C"], ["\u098F", "\u0990"], ["\u0993", "\u09A8"], ["\u09AA", "\u09B0"], "\u09B2", ["\u09B6", "\u09B9"], "\u09BD", "\u09CE", ["\u09DC", "\u09DD"], ["\u09DF", "\u09E1"], ["\u09F0", "\u09F1"], ["\u0A05", "\u0A0A"], ["\u0A0F", "\u0A10"], ["\u0A13", "\u0A28"], ["\u0A2A", "\u0A30"], ["\u0A32", "\u0A33"], ["\u0A35", "\u0A36"], ["\u0A38", "\u0A39"], ["\u0A59", "\u0A5C"], "\u0A5E", ["\u0A72", "\u0A74"], ["\u0A85", "\u0A8D"], ["\u0A8F", "\u0A91"], ["\u0A93", "\u0AA8"], ["\u0AAA", "\u0AB0"], ["\u0AB2", "\u0AB3"], ["\u0AB5", "\u0AB9"], "\u0ABD", "\u0AD0", ["\u0AE0", "\u0AE1"], "\u0AF9", ["\u0B05", "\u0B0C"], ["\u0B0F", "\u0B10"], ["\u0B13", "\u0B28"], ["\u0B2A", "\u0B30"], ["\u0B32", "\u0B33"], ["\u0B35", "\u0B39"], "\u0B3D", ["\u0B5C", "\u0B5D"], ["\u0B5F", "\u0B61"], "\u0B71", "\u0B83", ["\u0B85", "\u0B8A"], ["\u0B8E", "\u0B90"], ["\u0B92", "\u0B95"], ["\u0B99", "\u0B9A"], "\u0B9C", ["\u0B9E", "\u0B9F"], ["\u0BA3", "\u0BA4"], ["\u0BA8", "\u0BAA"], ["\u0BAE", "\u0BB9"], "\u0BD0", ["\u0C05", "\u0C0C"], ["\u0C0E", "\u0C10"], ["\u0C12", "\u0C28"], ["\u0C2A", "\u0C39"], "\u0C3D", ["\u0C58", "\u0C5A"], ["\u0C60", "\u0C61"], ["\u0C85", "\u0C8C"], ["\u0C8E", "\u0C90"], ["\u0C92", "\u0CA8"], ["\u0CAA", "\u0CB3"], ["\u0CB5", "\u0CB9"], "\u0CBD", "\u0CDE", ["\u0CE0", "\u0CE1"], ["\u0CF1", "\u0CF2"], ["\u0D05", "\u0D0C"], ["\u0D0E", "\u0D10"], ["\u0D12", "\u0D3A"], "\u0D3D", "\u0D4E", ["\u0D5F", "\u0D61"], ["\u0D7A", "\u0D7F"], ["\u0D85", "\u0D96"], ["\u0D9A", "\u0DB1"], ["\u0DB3", "\u0DBB"], "\u0DBD", ["\u0DC0", "\u0DC6"], ["\u0E01", "\u0E30"], ["\u0E32", "\u0E33"], ["\u0E40", "\u0E45"], ["\u0E81", "\u0E82"], "\u0E84", ["\u0E87", "\u0E88"], "\u0E8A", "\u0E8D", ["\u0E94", "\u0E97"], ["\u0E99", "\u0E9F"], ["\u0EA1", "\u0EA3"], "\u0EA5", "\u0EA7", ["\u0EAA", "\u0EAB"], ["\u0EAD", "\u0EB0"], ["\u0EB2", "\u0EB3"], "\u0EBD", ["\u0EC0", "\u0EC4"], ["\u0EDC", "\u0EDF"], "\u0F00", ["\u0F40", "\u0F47"], ["\u0F49", "\u0F6C"], ["\u0F88", "\u0F8C"], ["\u1000", "\u102A"], "\u103F", ["\u1050", "\u1055"], ["\u105A", "\u105D"], "\u1061", ["\u1065", "\u1066"], ["\u106E", "\u1070"], ["\u1075", "\u1081"], "\u108E", ["\u10D0", "\u10FA"], ["\u10FD", "\u1248"], ["\u124A", "\u124D"], ["\u1250", "\u1256"], "\u1258", ["\u125A", "\u125D"], ["\u1260", "\u1288"], ["\u128A", "\u128D"], ["\u1290", "\u12B0"], ["\u12B2", "\u12B5"], ["\u12B8", "\u12BE"], "\u12C0", ["\u12C2", "\u12C5"], ["\u12C8", "\u12D6"], ["\u12D8", "\u1310"], ["\u1312", "\u1315"], ["\u1318", "\u135A"], ["\u1380", "\u138F"], ["\u1401", "\u166C"], ["\u166F", "\u167F"], ["\u1681", "\u169A"], ["\u16A0", "\u16EA"], ["\u16F1", "\u16F8"], ["\u1700", "\u170C"], ["\u170E", "\u1711"], ["\u1720", "\u1731"], ["\u1740", "\u1751"], ["\u1760", "\u176C"], ["\u176E", "\u1770"], ["\u1780", "\u17B3"], "\u17DC", ["\u1820", "\u1842"], ["\u1844", "\u1877"], ["\u1880", "\u18A8"], "\u18AA", ["\u18B0", "\u18F5"], ["\u1900", "\u191E"], ["\u1950", "\u196D"], ["\u1970", "\u1974"], ["\u1980", "\u19AB"], ["\u19B0", "\u19C9"], ["\u1A00", "\u1A16"], ["\u1A20", "\u1A54"], ["\u1B05", "\u1B33"], ["\u1B45", "\u1B4B"], ["\u1B83", "\u1BA0"], ["\u1BAE", "\u1BAF"], ["\u1BBA", "\u1BE5"], ["\u1C00", "\u1C23"], ["\u1C4D", "\u1C4F"], ["\u1C5A", "\u1C77"], ["\u1CE9", "\u1CEC"], ["\u1CEE", "\u1CF1"], ["\u1CF5", "\u1CF6"], ["\u2135", "\u2138"], ["\u2D30", "\u2D67"], ["\u2D80", "\u2D96"], ["\u2DA0", "\u2DA6"], ["\u2DA8", "\u2DAE"], ["\u2DB0", "\u2DB6"], ["\u2DB8", "\u2DBE"], ["\u2DC0", "\u2DC6"], ["\u2DC8", "\u2DCE"], ["\u2DD0", "\u2DD6"], ["\u2DD8", "\u2DDE"], "\u3006", "\u303C", ["\u3041", "\u3096"], "\u309F", ["\u30A1", "\u30FA"], "\u30FF", ["\u3105", "\u312D"], ["\u3131", "\u318E"], ["\u31A0", "\u31BA"], ["\u31F0", "\u31FF"], ["\u3400", "\u4DB5"], ["\u4E00", "\u9FD5"], ["\uA000", "\uA014"], ["\uA016", "\uA48C"], ["\uA4D0", "\uA4F7"], ["\uA500", "\uA60B"], ["\uA610", "\uA61F"], ["\uA62A", "\uA62B"], "\uA66E", ["\uA6A0", "\uA6E5"], "\uA78F", "\uA7F7", ["\uA7FB", "\uA801"], ["\uA803", "\uA805"], ["\uA807", "\uA80A"], ["\uA80C", "\uA822"], ["\uA840", "\uA873"], ["\uA882", "\uA8B3"], ["\uA8F2", "\uA8F7"], "\uA8FB", "\uA8FD", ["\uA90A", "\uA925"], ["\uA930", "\uA946"], ["\uA960", "\uA97C"], ["\uA984", "\uA9B2"], ["\uA9E0", "\uA9E4"], ["\uA9E7", "\uA9EF"], ["\uA9FA", "\uA9FE"], ["\uAA00", "\uAA28"], ["\uAA40", "\uAA42"], ["\uAA44", "\uAA4B"], ["\uAA60", "\uAA6F"], ["\uAA71", "\uAA76"], "\uAA7A", ["\uAA7E", "\uAAAF"], "\uAAB1", ["\uAAB5", "\uAAB6"], ["\uAAB9", "\uAABD"], "\uAAC0", "\uAAC2", ["\uAADB", "\uAADC"], ["\uAAE0", "\uAAEA"], "\uAAF2", ["\uAB01", "\uAB06"], ["\uAB09", "\uAB0E"], ["\uAB11", "\uAB16"], ["\uAB20", "\uAB26"], ["\uAB28", "\uAB2E"], ["\uABC0", "\uABE2"], ["\uAC00", "\uD7A3"], ["\uD7B0", "\uD7C6"], ["\uD7CB", "\uD7FB"], ["\uF900", "\uFA6D"], ["\uFA70", "\uFAD9"], "\uFB1D", ["\uFB1F", "\uFB28"], ["\uFB2A", "\uFB36"], ["\uFB38", "\uFB3C"], "\uFB3E", ["\uFB40", "\uFB41"], ["\uFB43", "\uFB44"], ["\uFB46", "\uFBB1"], ["\uFBD3", "\uFD3D"], ["\uFD50", "\uFD8F"], ["\uFD92", "\uFDC7"], ["\uFDF0", "\uFDFB"], ["\uFE70", "\uFE74"], ["\uFE76", "\uFEFC"], ["\uFF66", "\uFF6F"], ["\uFF71", "\uFF9D"], ["\uFFA0", "\uFFBE"], ["\uFFC2", "\uFFC7"], ["\uFFCA", "\uFFCF"], ["\uFFD2", "\uFFD7"], ["\uFFDA", "\uFFDC"]], false, false);
+  var peg$c121 = /^[\u01C5\u01C8\u01CB\u01F2\u1F88-\u1F8F\u1F98-\u1F9F\u1FA8-\u1FAF\u1FBC\u1FCC\u1FFC]/;
+  var peg$c122 = peg$classExpectation(["\u01C5", "\u01C8", "\u01CB", "\u01F2", ["\u1F88", "\u1F8F"], ["\u1F98", "\u1F9F"], ["\u1FA8", "\u1FAF"], "\u1FBC", "\u1FCC", "\u1FFC"], false, false);
+  var peg$c123 = /^[A-Z\xC0-\xD6\xD8-\xDE\u0100\u0102\u0104\u0106\u0108\u010A\u010C\u010E\u0110\u0112\u0114\u0116\u0118\u011A\u011C\u011E\u0120\u0122\u0124\u0126\u0128\u012A\u012C\u012E\u0130\u0132\u0134\u0136\u0139\u013B\u013D\u013F\u0141\u0143\u0145\u0147\u014A\u014C\u014E\u0150\u0152\u0154\u0156\u0158\u015A\u015C\u015E\u0160\u0162\u0164\u0166\u0168\u016A\u016C\u016E\u0170\u0172\u0174\u0176\u0178-\u0179\u017B\u017D\u0181-\u0182\u0184\u0186-\u0187\u0189-\u018B\u018E-\u0191\u0193-\u0194\u0196-\u0198\u019C-\u019D\u019F-\u01A0\u01A2\u01A4\u01A6-\u01A7\u01A9\u01AC\u01AE-\u01AF\u01B1-\u01B3\u01B5\u01B7-\u01B8\u01BC\u01C4\u01C7\u01CA\u01CD\u01CF\u01D1\u01D3\u01D5\u01D7\u01D9\u01DB\u01DE\u01E0\u01E2\u01E4\u01E6\u01E8\u01EA\u01EC\u01EE\u01F1\u01F4\u01F6-\u01F8\u01FA\u01FC\u01FE\u0200\u0202\u0204\u0206\u0208\u020A\u020C\u020E\u0210\u0212\u0214\u0216\u0218\u021A\u021C\u021E\u0220\u0222\u0224\u0226\u0228\u022A\u022C\u022E\u0230\u0232\u023A-\u023B\u023D-\u023E\u0241\u0243-\u0246\u0248\u024A\u024C\u024E\u0370\u0372\u0376\u037F\u0386\u0388-\u038A\u038C\u038E-\u038F\u0391-\u03A1\u03A3-\u03AB\u03CF\u03D2-\u03D4\u03D8\u03DA\u03DC\u03DE\u03E0\u03E2\u03E4\u03E6\u03E8\u03EA\u03EC\u03EE\u03F4\u03F7\u03F9-\u03FA\u03FD-\u042F\u0460\u0462\u0464\u0466\u0468\u046A\u046C\u046E\u0470\u0472\u0474\u0476\u0478\u047A\u047C\u047E\u0480\u048A\u048C\u048E\u0490\u0492\u0494\u0496\u0498\u049A\u049C\u049E\u04A0\u04A2\u04A4\u04A6\u04A8\u04AA\u04AC\u04AE\u04B0\u04B2\u04B4\u04B6\u04B8\u04BA\u04BC\u04BE\u04C0-\u04C1\u04C3\u04C5\u04C7\u04C9\u04CB\u04CD\u04D0\u04D2\u04D4\u04D6\u04D8\u04DA\u04DC\u04DE\u04E0\u04E2\u04E4\u04E6\u04E8\u04EA\u04EC\u04EE\u04F0\u04F2\u04F4\u04F6\u04F8\u04FA\u04FC\u04FE\u0500\u0502\u0504\u0506\u0508\u050A\u050C\u050E\u0510\u0512\u0514\u0516\u0518\u051A\u051C\u051E\u0520\u0522\u0524\u0526\u0528\u052A\u052C\u052E\u0531-\u0556\u10A0-\u10C5\u10C7\u10CD\u13A0-\u13F5\u1E00\u1E02\u1E04\u1E06\u1E08\u1E0A\u1E0C\u1E0E\u1E10\u1E12\u1E14\u1E16\u1E18\u1E1A\u1E1C\u1E1E\u1E20\u1E22\u1E24\u1E26\u1E28\u1E2A\u1E2C\u1E2E\u1E30\u1E32\u1E34\u1E36\u1E38\u1E3A\u1E3C\u1E3E\u1E40\u1E42\u1E44\u1E46\u1E48\u1E4A\u1E4C\u1E4E\u1E50\u1E52\u1E54\u1E56\u1E58\u1E5A\u1E5C\u1E5E\u1E60\u1E62\u1E64\u1E66\u1E68\u1E6A\u1E6C\u1E6E\u1E70\u1E72\u1E74\u1E76\u1E78\u1E7A\u1E7C\u1E7E\u1E80\u1E82\u1E84\u1E86\u1E88\u1E8A\u1E8C\u1E8E\u1E90\u1E92\u1E94\u1E9E\u1EA0\u1EA2\u1EA4\u1EA6\u1EA8\u1EAA\u1EAC\u1EAE\u1EB0\u1EB2\u1EB4\u1EB6\u1EB8\u1EBA\u1EBC\u1EBE\u1EC0\u1EC2\u1EC4\u1EC6\u1EC8\u1ECA\u1ECC\u1ECE\u1ED0\u1ED2\u1ED4\u1ED6\u1ED8\u1EDA\u1EDC\u1EDE\u1EE0\u1EE2\u1EE4\u1EE6\u1EE8\u1EEA\u1EEC\u1EEE\u1EF0\u1EF2\u1EF4\u1EF6\u1EF8\u1EFA\u1EFC\u1EFE\u1F08-\u1F0F\u1F18-\u1F1D\u1F28-\u1F2F\u1F38-\u1F3F\u1F48-\u1F4D\u1F59\u1F5B\u1F5D\u1F5F\u1F68-\u1F6F\u1FB8-\u1FBB\u1FC8-\u1FCB\u1FD8-\u1FDB\u1FE8-\u1FEC\u1FF8-\u1FFB\u2102\u2107\u210B-\u210D\u2110-\u2112\u2115\u2119-\u211D\u2124\u2126\u2128\u212A-\u212D\u2130-\u2133\u213E-\u213F\u2145\u2183\u2C00-\u2C2E\u2C60\u2C62-\u2C64\u2C67\u2C69\u2C6B\u2C6D-\u2C70\u2C72\u2C75\u2C7E-\u2C80\u2C82\u2C84\u2C86\u2C88\u2C8A\u2C8C\u2C8E\u2C90\u2C92\u2C94\u2C96\u2C98\u2C9A\u2C9C\u2C9E\u2CA0\u2CA2\u2CA4\u2CA6\u2CA8\u2CAA\u2CAC\u2CAE\u2CB0\u2CB2\u2CB4\u2CB6\u2CB8\u2CBA\u2CBC\u2CBE\u2CC0\u2CC2\u2CC4\u2CC6\u2CC8\u2CCA\u2CCC\u2CCE\u2CD0\u2CD2\u2CD4\u2CD6\u2CD8\u2CDA\u2CDC\u2CDE\u2CE0\u2CE2\u2CEB\u2CED\u2CF2\uA640\uA642\uA644\uA646\uA648\uA64A\uA64C\uA64E\uA650\uA652\uA654\uA656\uA658\uA65A\uA65C\uA65E\uA660\uA662\uA664\uA666\uA668\uA66A\uA66C\uA680\uA682\uA684\uA686\uA688\uA68A\uA68C\uA68E\uA690\uA692\uA694\uA696\uA698\uA69A\uA722\uA724\uA726\uA728\uA72A\uA72C\uA72E\uA732\uA734\uA736\uA738\uA73A\uA73C\uA73E\uA740\uA742\uA744\uA746\uA748\uA74A\uA74C\uA74E\uA750\uA752\uA754\uA756\uA758\uA75A\uA75C\uA75E\uA760\uA762\uA764\uA766\uA768\uA76A\uA76C\uA76E\uA779\uA77B\uA77D-\uA77E\uA780\uA782\uA784\uA786\uA78B\uA78D\uA790\uA792\uA796\uA798\uA79A\uA79C\uA79E\uA7A0\uA7A2\uA7A4\uA7A6\uA7A8\uA7AA-\uA7AD\uA7B0-\uA7B4\uA7B6\uFF21-\uFF3A]/;
+  var peg$c124 = peg$classExpectation([["A", "Z"], ["\xC0", "\xD6"], ["\xD8", "\xDE"], "\u0100", "\u0102", "\u0104", "\u0106", "\u0108", "\u010A", "\u010C", "\u010E", "\u0110", "\u0112", "\u0114", "\u0116", "\u0118", "\u011A", "\u011C", "\u011E", "\u0120", "\u0122", "\u0124", "\u0126", "\u0128", "\u012A", "\u012C", "\u012E", "\u0130", "\u0132", "\u0134", "\u0136", "\u0139", "\u013B", "\u013D", "\u013F", "\u0141", "\u0143", "\u0145", "\u0147", "\u014A", "\u014C", "\u014E", "\u0150", "\u0152", "\u0154", "\u0156", "\u0158", "\u015A", "\u015C", "\u015E", "\u0160", "\u0162", "\u0164", "\u0166", "\u0168", "\u016A", "\u016C", "\u016E", "\u0170", "\u0172", "\u0174", "\u0176", ["\u0178", "\u0179"], "\u017B", "\u017D", ["\u0181", "\u0182"], "\u0184", ["\u0186", "\u0187"], ["\u0189", "\u018B"], ["\u018E", "\u0191"], ["\u0193", "\u0194"], ["\u0196", "\u0198"], ["\u019C", "\u019D"], ["\u019F", "\u01A0"], "\u01A2", "\u01A4", ["\u01A6", "\u01A7"], "\u01A9", "\u01AC", ["\u01AE", "\u01AF"], ["\u01B1", "\u01B3"], "\u01B5", ["\u01B7", "\u01B8"], "\u01BC", "\u01C4", "\u01C7", "\u01CA", "\u01CD", "\u01CF", "\u01D1", "\u01D3", "\u01D5", "\u01D7", "\u01D9", "\u01DB", "\u01DE", "\u01E0", "\u01E2", "\u01E4", "\u01E6", "\u01E8", "\u01EA", "\u01EC", "\u01EE", "\u01F1", "\u01F4", ["\u01F6", "\u01F8"], "\u01FA", "\u01FC", "\u01FE", "\u0200", "\u0202", "\u0204", "\u0206", "\u0208", "\u020A", "\u020C", "\u020E", "\u0210", "\u0212", "\u0214", "\u0216", "\u0218", "\u021A", "\u021C", "\u021E", "\u0220", "\u0222", "\u0224", "\u0226", "\u0228", "\u022A", "\u022C", "\u022E", "\u0230", "\u0232", ["\u023A", "\u023B"], ["\u023D", "\u023E"], "\u0241", ["\u0243", "\u0246"], "\u0248", "\u024A", "\u024C", "\u024E", "\u0370", "\u0372", "\u0376", "\u037F", "\u0386", ["\u0388", "\u038A"], "\u038C", ["\u038E", "\u038F"], ["\u0391", "\u03A1"], ["\u03A3", "\u03AB"], "\u03CF", ["\u03D2", "\u03D4"], "\u03D8", "\u03DA", "\u03DC", "\u03DE", "\u03E0", "\u03E2", "\u03E4", "\u03E6", "\u03E8", "\u03EA", "\u03EC", "\u03EE", "\u03F4", "\u03F7", ["\u03F9", "\u03FA"], ["\u03FD", "\u042F"], "\u0460", "\u0462", "\u0464", "\u0466", "\u0468", "\u046A", "\u046C", "\u046E", "\u0470", "\u0472", "\u0474", "\u0476", "\u0478", "\u047A", "\u047C", "\u047E", "\u0480", "\u048A", "\u048C", "\u048E", "\u0490", "\u0492", "\u0494", "\u0496", "\u0498", "\u049A", "\u049C", "\u049E", "\u04A0", "\u04A2", "\u04A4", "\u04A6", "\u04A8", "\u04AA", "\u04AC", "\u04AE", "\u04B0", "\u04B2", "\u04B4", "\u04B6", "\u04B8", "\u04BA", "\u04BC", "\u04BE", ["\u04C0", "\u04C1"], "\u04C3", "\u04C5", "\u04C7", "\u04C9", "\u04CB", "\u04CD", "\u04D0", "\u04D2", "\u04D4", "\u04D6", "\u04D8", "\u04DA", "\u04DC", "\u04DE", "\u04E0", "\u04E2", "\u04E4", "\u04E6", "\u04E8", "\u04EA", "\u04EC", "\u04EE", "\u04F0", "\u04F2", "\u04F4", "\u04F6", "\u04F8", "\u04FA", "\u04FC", "\u04FE", "\u0500", "\u0502", "\u0504", "\u0506", "\u0508", "\u050A", "\u050C", "\u050E", "\u0510", "\u0512", "\u0514", "\u0516", "\u0518", "\u051A", "\u051C", "\u051E", "\u0520", "\u0522", "\u0524", "\u0526", "\u0528", "\u052A", "\u052C", "\u052E", ["\u0531", "\u0556"], ["\u10A0", "\u10C5"], "\u10C7", "\u10CD", ["\u13A0", "\u13F5"], "\u1E00", "\u1E02", "\u1E04", "\u1E06", "\u1E08", "\u1E0A", "\u1E0C", "\u1E0E", "\u1E10", "\u1E12", "\u1E14", "\u1E16", "\u1E18", "\u1E1A", "\u1E1C", "\u1E1E", "\u1E20", "\u1E22", "\u1E24", "\u1E26", "\u1E28", "\u1E2A", "\u1E2C", "\u1E2E", "\u1E30", "\u1E32", "\u1E34", "\u1E36", "\u1E38", "\u1E3A", "\u1E3C", "\u1E3E", "\u1E40", "\u1E42", "\u1E44", "\u1E46", "\u1E48", "\u1E4A", "\u1E4C", "\u1E4E", "\u1E50", "\u1E52", "\u1E54", "\u1E56", "\u1E58", "\u1E5A", "\u1E5C", "\u1E5E", "\u1E60", "\u1E62", "\u1E64", "\u1E66", "\u1E68", "\u1E6A", "\u1E6C", "\u1E6E", "\u1E70", "\u1E72", "\u1E74", "\u1E76", "\u1E78", "\u1E7A", "\u1E7C", "\u1E7E", "\u1E80", "\u1E82", "\u1E84", "\u1E86", "\u1E88", "\u1E8A", "\u1E8C", "\u1E8E", "\u1E90", "\u1E92", "\u1E94", "\u1E9E", "\u1EA0", "\u1EA2", "\u1EA4", "\u1EA6", "\u1EA8", "\u1EAA", "\u1EAC", "\u1EAE", "\u1EB0", "\u1EB2", "\u1EB4", "\u1EB6", "\u1EB8", "\u1EBA", "\u1EBC", "\u1EBE", "\u1EC0", "\u1EC2", "\u1EC4", "\u1EC6", "\u1EC8", "\u1ECA", "\u1ECC", "\u1ECE", "\u1ED0", "\u1ED2", "\u1ED4", "\u1ED6", "\u1ED8", "\u1EDA", "\u1EDC", "\u1EDE", "\u1EE0", "\u1EE2", "\u1EE4", "\u1EE6", "\u1EE8", "\u1EEA", "\u1EEC", "\u1EEE", "\u1EF0", "\u1EF2", "\u1EF4", "\u1EF6", "\u1EF8", "\u1EFA", "\u1EFC", "\u1EFE", ["\u1F08", "\u1F0F"], ["\u1F18", "\u1F1D"], ["\u1F28", "\u1F2F"], ["\u1F38", "\u1F3F"], ["\u1F48", "\u1F4D"], "\u1F59", "\u1F5B", "\u1F5D", "\u1F5F", ["\u1F68", "\u1F6F"], ["\u1FB8", "\u1FBB"], ["\u1FC8", "\u1FCB"], ["\u1FD8", "\u1FDB"], ["\u1FE8", "\u1FEC"], ["\u1FF8", "\u1FFB"], "\u2102", "\u2107", ["\u210B", "\u210D"], ["\u2110", "\u2112"], "\u2115", ["\u2119", "\u211D"], "\u2124", "\u2126", "\u2128", ["\u212A", "\u212D"], ["\u2130", "\u2133"], ["\u213E", "\u213F"], "\u2145", "\u2183", ["\u2C00", "\u2C2E"], "\u2C60", ["\u2C62", "\u2C64"], "\u2C67", "\u2C69", "\u2C6B", ["\u2C6D", "\u2C70"], "\u2C72", "\u2C75", ["\u2C7E", "\u2C80"], "\u2C82", "\u2C84", "\u2C86", "\u2C88", "\u2C8A", "\u2C8C", "\u2C8E", "\u2C90", "\u2C92", "\u2C94", "\u2C96", "\u2C98", "\u2C9A", "\u2C9C", "\u2C9E", "\u2CA0", "\u2CA2", "\u2CA4", "\u2CA6", "\u2CA8", "\u2CAA", "\u2CAC", "\u2CAE", "\u2CB0", "\u2CB2", "\u2CB4", "\u2CB6", "\u2CB8", "\u2CBA", "\u2CBC", "\u2CBE", "\u2CC0", "\u2CC2", "\u2CC4", "\u2CC6", "\u2CC8", "\u2CCA", "\u2CCC", "\u2CCE", "\u2CD0", "\u2CD2", "\u2CD4", "\u2CD6", "\u2CD8", "\u2CDA", "\u2CDC", "\u2CDE", "\u2CE0", "\u2CE2", "\u2CEB", "\u2CED", "\u2CF2", "\uA640", "\uA642", "\uA644", "\uA646", "\uA648", "\uA64A", "\uA64C", "\uA64E", "\uA650", "\uA652", "\uA654", "\uA656", "\uA658", "\uA65A", "\uA65C", "\uA65E", "\uA660", "\uA662", "\uA664", "\uA666", "\uA668", "\uA66A", "\uA66C", "\uA680", "\uA682", "\uA684", "\uA686", "\uA688", "\uA68A", "\uA68C", "\uA68E", "\uA690", "\uA692", "\uA694", "\uA696", "\uA698", "\uA69A", "\uA722", "\uA724", "\uA726", "\uA728", "\uA72A", "\uA72C", "\uA72E", "\uA732", "\uA734", "\uA736", "\uA738", "\uA73A", "\uA73C", "\uA73E", "\uA740", "\uA742", "\uA744", "\uA746", "\uA748", "\uA74A", "\uA74C", "\uA74E", "\uA750", "\uA752", "\uA754", "\uA756", "\uA758", "\uA75A", "\uA75C", "\uA75E", "\uA760", "\uA762", "\uA764", "\uA766", "\uA768", "\uA76A", "\uA76C", "\uA76E", "\uA779", "\uA77B", ["\uA77D", "\uA77E"], "\uA780", "\uA782", "\uA784", "\uA786", "\uA78B", "\uA78D", "\uA790", "\uA792", "\uA796", "\uA798", "\uA79A", "\uA79C", "\uA79E", "\uA7A0", "\uA7A2", "\uA7A4", "\uA7A6", "\uA7A8", ["\uA7AA", "\uA7AD"], ["\uA7B0", "\uA7B4"], "\uA7B6", ["\uFF21", "\uFF3A"]], false, false);
+  var peg$c125 = /^[\u0903\u093B\u093E-\u0940\u0949-\u094C\u094E-\u094F\u0982-\u0983\u09BE-\u09C0\u09C7-\u09C8\u09CB-\u09CC\u09D7\u0A03\u0A3E-\u0A40\u0A83\u0ABE-\u0AC0\u0AC9\u0ACB-\u0ACC\u0B02-\u0B03\u0B3E\u0B40\u0B47-\u0B48\u0B4B-\u0B4C\u0B57\u0BBE-\u0BBF\u0BC1-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCC\u0BD7\u0C01-\u0C03\u0C41-\u0C44\u0C82-\u0C83\u0CBE\u0CC0-\u0CC4\u0CC7-\u0CC8\u0CCA-\u0CCB\u0CD5-\u0CD6\u0D02-\u0D03\u0D3E-\u0D40\u0D46-\u0D48\u0D4A-\u0D4C\u0D57\u0D82-\u0D83\u0DCF-\u0DD1\u0DD8-\u0DDF\u0DF2-\u0DF3\u0F3E-\u0F3F\u0F7F\u102B-\u102C\u1031\u1038\u103B-\u103C\u1056-\u1057\u1062-\u1064\u1067-\u106D\u1083-\u1084\u1087-\u108C\u108F\u109A-\u109C\u17B6\u17BE-\u17C5\u17C7-\u17C8\u1923-\u1926\u1929-\u192B\u1930-\u1931\u1933-\u1938\u1A19-\u1A1A\u1A55\u1A57\u1A61\u1A63-\u1A64\u1A6D-\u1A72\u1B04\u1B35\u1B3B\u1B3D-\u1B41\u1B43-\u1B44\u1B82\u1BA1\u1BA6-\u1BA7\u1BAA\u1BE7\u1BEA-\u1BEC\u1BEE\u1BF2-\u1BF3\u1C24-\u1C2B\u1C34-\u1C35\u1CE1\u1CF2-\u1CF3\u302E-\u302F\uA823-\uA824\uA827\uA880-\uA881\uA8B4-\uA8C3\uA952-\uA953\uA983\uA9B4-\uA9B5\uA9BA-\uA9BB\uA9BD-\uA9C0\uAA2F-\uAA30\uAA33-\uAA34\uAA4D\uAA7B\uAA7D\uAAEB\uAAEE-\uAAEF\uAAF5\uABE3-\uABE4\uABE6-\uABE7\uABE9-\uABEA\uABEC]/;
+  var peg$c126 = peg$classExpectation(["\u0903", "\u093B", ["\u093E", "\u0940"], ["\u0949", "\u094C"], ["\u094E", "\u094F"], ["\u0982", "\u0983"], ["\u09BE", "\u09C0"], ["\u09C7", "\u09C8"], ["\u09CB", "\u09CC"], "\u09D7", "\u0A03", ["\u0A3E", "\u0A40"], "\u0A83", ["\u0ABE", "\u0AC0"], "\u0AC9", ["\u0ACB", "\u0ACC"], ["\u0B02", "\u0B03"], "\u0B3E", "\u0B40", ["\u0B47", "\u0B48"], ["\u0B4B", "\u0B4C"], "\u0B57", ["\u0BBE", "\u0BBF"], ["\u0BC1", "\u0BC2"], ["\u0BC6", "\u0BC8"], ["\u0BCA", "\u0BCC"], "\u0BD7", ["\u0C01", "\u0C03"], ["\u0C41", "\u0C44"], ["\u0C82", "\u0C83"], "\u0CBE", ["\u0CC0", "\u0CC4"], ["\u0CC7", "\u0CC8"], ["\u0CCA", "\u0CCB"], ["\u0CD5", "\u0CD6"], ["\u0D02", "\u0D03"], ["\u0D3E", "\u0D40"], ["\u0D46", "\u0D48"], ["\u0D4A", "\u0D4C"], "\u0D57", ["\u0D82", "\u0D83"], ["\u0DCF", "\u0DD1"], ["\u0DD8", "\u0DDF"], ["\u0DF2", "\u0DF3"], ["\u0F3E", "\u0F3F"], "\u0F7F", ["\u102B", "\u102C"], "\u1031", "\u1038", ["\u103B", "\u103C"], ["\u1056", "\u1057"], ["\u1062", "\u1064"], ["\u1067", "\u106D"], ["\u1083", "\u1084"], ["\u1087", "\u108C"], "\u108F", ["\u109A", "\u109C"], "\u17B6", ["\u17BE", "\u17C5"], ["\u17C7", "\u17C8"], ["\u1923", "\u1926"], ["\u1929", "\u192B"], ["\u1930", "\u1931"], ["\u1933", "\u1938"], ["\u1A19", "\u1A1A"], "\u1A55", "\u1A57", "\u1A61", ["\u1A63", "\u1A64"], ["\u1A6D", "\u1A72"], "\u1B04", "\u1B35", "\u1B3B", ["\u1B3D", "\u1B41"], ["\u1B43", "\u1B44"], "\u1B82", "\u1BA1", ["\u1BA6", "\u1BA7"], "\u1BAA", "\u1BE7", ["\u1BEA", "\u1BEC"], "\u1BEE", ["\u1BF2", "\u1BF3"], ["\u1C24", "\u1C2B"], ["\u1C34", "\u1C35"], "\u1CE1", ["\u1CF2", "\u1CF3"], ["\u302E", "\u302F"], ["\uA823", "\uA824"], "\uA827", ["\uA880", "\uA881"], ["\uA8B4", "\uA8C3"], ["\uA952", "\uA953"], "\uA983", ["\uA9B4", "\uA9B5"], ["\uA9BA", "\uA9BB"], ["\uA9BD", "\uA9C0"], ["\uAA2F", "\uAA30"], ["\uAA33", "\uAA34"], "\uAA4D", "\uAA7B", "\uAA7D", "\uAAEB", ["\uAAEE", "\uAAEF"], "\uAAF5", ["\uABE3", "\uABE4"], ["\uABE6", "\uABE7"], ["\uABE9", "\uABEA"], "\uABEC"], false, false);
+  var peg$c127 = /^[\u0300-\u036F\u0483-\u0487\u0591-\u05BD\u05BF\u05C1-\u05C2\u05C4-\u05C5\u05C7\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7-\u06E8\u06EA-\u06ED\u0711\u0730-\u074A\u07A6-\u07B0\u07EB-\u07F3\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u08E3-\u0902\u093A\u093C\u0941-\u0948\u094D\u0951-\u0957\u0962-\u0963\u0981\u09BC\u09C1-\u09C4\u09CD\u09E2-\u09E3\u0A01-\u0A02\u0A3C\u0A41-\u0A42\u0A47-\u0A48\u0A4B-\u0A4D\u0A51\u0A70-\u0A71\u0A75\u0A81-\u0A82\u0ABC\u0AC1-\u0AC5\u0AC7-\u0AC8\u0ACD\u0AE2-\u0AE3\u0B01\u0B3C\u0B3F\u0B41-\u0B44\u0B4D\u0B56\u0B62-\u0B63\u0B82\u0BC0\u0BCD\u0C00\u0C3E-\u0C40\u0C46-\u0C48\u0C4A-\u0C4D\u0C55-\u0C56\u0C62-\u0C63\u0C81\u0CBC\u0CBF\u0CC6\u0CCC-\u0CCD\u0CE2-\u0CE3\u0D01\u0D41-\u0D44\u0D4D\u0D62-\u0D63\u0DCA\u0DD2-\u0DD4\u0DD6\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0EB1\u0EB4-\u0EB9\u0EBB-\u0EBC\u0EC8-\u0ECD\u0F18-\u0F19\u0F35\u0F37\u0F39\u0F71-\u0F7E\u0F80-\u0F84\u0F86-\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102D-\u1030\u1032-\u1037\u1039-\u103A\u103D-\u103E\u1058-\u1059\u105E-\u1060\u1071-\u1074\u1082\u1085-\u1086\u108D\u109D\u135D-\u135F\u1712-\u1714\u1732-\u1734\u1752-\u1753\u1772-\u1773\u17B4-\u17B5\u17B7-\u17BD\u17C6\u17C9-\u17D3\u17DD\u180B-\u180D\u18A9\u1920-\u1922\u1927-\u1928\u1932\u1939-\u193B\u1A17-\u1A18\u1A1B\u1A56\u1A58-\u1A5E\u1A60\u1A62\u1A65-\u1A6C\u1A73-\u1A7C\u1A7F\u1AB0-\u1ABD\u1B00-\u1B03\u1B34\u1B36-\u1B3A\u1B3C\u1B42\u1B6B-\u1B73\u1B80-\u1B81\u1BA2-\u1BA5\u1BA8-\u1BA9\u1BAB-\u1BAD\u1BE6\u1BE8-\u1BE9\u1BED\u1BEF-\u1BF1\u1C2C-\u1C33\u1C36-\u1C37\u1CD0-\u1CD2\u1CD4-\u1CE0\u1CE2-\u1CE8\u1CED\u1CF4\u1CF8-\u1CF9\u1DC0-\u1DF5\u1DFC-\u1DFF\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302D\u3099-\u309A\uA66F\uA674-\uA67D\uA69E-\uA69F\uA6F0-\uA6F1\uA802\uA806\uA80B\uA825-\uA826\uA8C4\uA8E0-\uA8F1\uA926-\uA92D\uA947-\uA951\uA980-\uA982\uA9B3\uA9B6-\uA9B9\uA9BC\uA9E5\uAA29-\uAA2E\uAA31-\uAA32\uAA35-\uAA36\uAA43\uAA4C\uAA7C\uAAB0\uAAB2-\uAAB4\uAAB7-\uAAB8\uAABE-\uAABF\uAAC1\uAAEC-\uAAED\uAAF6\uABE5\uABE8\uABED\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F]/;
+  var peg$c128 = peg$classExpectation([["\u0300", "\u036F"], ["\u0483", "\u0487"], ["\u0591", "\u05BD"], "\u05BF", ["\u05C1", "\u05C2"], ["\u05C4", "\u05C5"], "\u05C7", ["\u0610", "\u061A"], ["\u064B", "\u065F"], "\u0670", ["\u06D6", "\u06DC"], ["\u06DF", "\u06E4"], ["\u06E7", "\u06E8"], ["\u06EA", "\u06ED"], "\u0711", ["\u0730", "\u074A"], ["\u07A6", "\u07B0"], ["\u07EB", "\u07F3"], ["\u0816", "\u0819"], ["\u081B", "\u0823"], ["\u0825", "\u0827"], ["\u0829", "\u082D"], ["\u0859", "\u085B"], ["\u08E3", "\u0902"], "\u093A", "\u093C", ["\u0941", "\u0948"], "\u094D", ["\u0951", "\u0957"], ["\u0962", "\u0963"], "\u0981", "\u09BC", ["\u09C1", "\u09C4"], "\u09CD", ["\u09E2", "\u09E3"], ["\u0A01", "\u0A02"], "\u0A3C", ["\u0A41", "\u0A42"], ["\u0A47", "\u0A48"], ["\u0A4B", "\u0A4D"], "\u0A51", ["\u0A70", "\u0A71"], "\u0A75", ["\u0A81", "\u0A82"], "\u0ABC", ["\u0AC1", "\u0AC5"], ["\u0AC7", "\u0AC8"], "\u0ACD", ["\u0AE2", "\u0AE3"], "\u0B01", "\u0B3C", "\u0B3F", ["\u0B41", "\u0B44"], "\u0B4D", "\u0B56", ["\u0B62", "\u0B63"], "\u0B82", "\u0BC0", "\u0BCD", "\u0C00", ["\u0C3E", "\u0C40"], ["\u0C46", "\u0C48"], ["\u0C4A", "\u0C4D"], ["\u0C55", "\u0C56"], ["\u0C62", "\u0C63"], "\u0C81", "\u0CBC", "\u0CBF", "\u0CC6", ["\u0CCC", "\u0CCD"], ["\u0CE2", "\u0CE3"], "\u0D01", ["\u0D41", "\u0D44"], "\u0D4D", ["\u0D62", "\u0D63"], "\u0DCA", ["\u0DD2", "\u0DD4"], "\u0DD6", "\u0E31", ["\u0E34", "\u0E3A"], ["\u0E47", "\u0E4E"], "\u0EB1", ["\u0EB4", "\u0EB9"], ["\u0EBB", "\u0EBC"], ["\u0EC8", "\u0ECD"], ["\u0F18", "\u0F19"], "\u0F35", "\u0F37", "\u0F39", ["\u0F71", "\u0F7E"], ["\u0F80", "\u0F84"], ["\u0F86", "\u0F87"], ["\u0F8D", "\u0F97"], ["\u0F99", "\u0FBC"], "\u0FC6", ["\u102D", "\u1030"], ["\u1032", "\u1037"], ["\u1039", "\u103A"], ["\u103D", "\u103E"], ["\u1058", "\u1059"], ["\u105E", "\u1060"], ["\u1071", "\u1074"], "\u1082", ["\u1085", "\u1086"], "\u108D", "\u109D", ["\u135D", "\u135F"], ["\u1712", "\u1714"], ["\u1732", "\u1734"], ["\u1752", "\u1753"], ["\u1772", "\u1773"], ["\u17B4", "\u17B5"], ["\u17B7", "\u17BD"], "\u17C6", ["\u17C9", "\u17D3"], "\u17DD", ["\u180B", "\u180D"], "\u18A9", ["\u1920", "\u1922"], ["\u1927", "\u1928"], "\u1932", ["\u1939", "\u193B"], ["\u1A17", "\u1A18"], "\u1A1B", "\u1A56", ["\u1A58", "\u1A5E"], "\u1A60", "\u1A62", ["\u1A65", "\u1A6C"], ["\u1A73", "\u1A7C"], "\u1A7F", ["\u1AB0", "\u1ABD"], ["\u1B00", "\u1B03"], "\u1B34", ["\u1B36", "\u1B3A"], "\u1B3C", "\u1B42", ["\u1B6B", "\u1B73"], ["\u1B80", "\u1B81"], ["\u1BA2", "\u1BA5"], ["\u1BA8", "\u1BA9"], ["\u1BAB", "\u1BAD"], "\u1BE6", ["\u1BE8", "\u1BE9"], "\u1BED", ["\u1BEF", "\u1BF1"], ["\u1C2C", "\u1C33"], ["\u1C36", "\u1C37"], ["\u1CD0", "\u1CD2"], ["\u1CD4", "\u1CE0"], ["\u1CE2", "\u1CE8"], "\u1CED", "\u1CF4", ["\u1CF8", "\u1CF9"], ["\u1DC0", "\u1DF5"], ["\u1DFC", "\u1DFF"], ["\u20D0", "\u20DC"], "\u20E1", ["\u20E5", "\u20F0"], ["\u2CEF", "\u2CF1"], "\u2D7F", ["\u2DE0", "\u2DFF"], ["\u302A", "\u302D"], ["\u3099", "\u309A"], "\uA66F", ["\uA674", "\uA67D"], ["\uA69E", "\uA69F"], ["\uA6F0", "\uA6F1"], "\uA802", "\uA806", "\uA80B", ["\uA825", "\uA826"], "\uA8C4", ["\uA8E0", "\uA8F1"], ["\uA926", "\uA92D"], ["\uA947", "\uA951"], ["\uA980", "\uA982"], "\uA9B3", ["\uA9B6", "\uA9B9"], "\uA9BC", "\uA9E5", ["\uAA29", "\uAA2E"], ["\uAA31", "\uAA32"], ["\uAA35", "\uAA36"], "\uAA43", "\uAA4C", "\uAA7C", "\uAAB0", ["\uAAB2", "\uAAB4"], ["\uAAB7", "\uAAB8"], ["\uAABE", "\uAABF"], "\uAAC1", ["\uAAEC", "\uAAED"], "\uAAF6", "\uABE5", "\uABE8", "\uABED", "\uFB1E", ["\uFE00", "\uFE0F"], ["\uFE20", "\uFE2F"]], false, false);
+  var peg$c129 = /^[0-9\u0660-\u0669\u06F0-\u06F9\u07C0-\u07C9\u0966-\u096F\u09E6-\u09EF\u0A66-\u0A6F\u0AE6-\u0AEF\u0B66-\u0B6F\u0BE6-\u0BEF\u0C66-\u0C6F\u0CE6-\u0CEF\u0D66-\u0D6F\u0DE6-\u0DEF\u0E50-\u0E59\u0ED0-\u0ED9\u0F20-\u0F29\u1040-\u1049\u1090-\u1099\u17E0-\u17E9\u1810-\u1819\u1946-\u194F\u19D0-\u19D9\u1A80-\u1A89\u1A90-\u1A99\u1B50-\u1B59\u1BB0-\u1BB9\u1C40-\u1C49\u1C50-\u1C59\uA620-\uA629\uA8D0-\uA8D9\uA900-\uA909\uA9D0-\uA9D9\uA9F0-\uA9F9\uAA50-\uAA59\uABF0-\uABF9\uFF10-\uFF19]/;
+  var peg$c130 = peg$classExpectation([["0", "9"], ["\u0660", "\u0669"], ["\u06F0", "\u06F9"], ["\u07C0", "\u07C9"], ["\u0966", "\u096F"], ["\u09E6", "\u09EF"], ["\u0A66", "\u0A6F"], ["\u0AE6", "\u0AEF"], ["\u0B66", "\u0B6F"], ["\u0BE6", "\u0BEF"], ["\u0C66", "\u0C6F"], ["\u0CE6", "\u0CEF"], ["\u0D66", "\u0D6F"], ["\u0DE6", "\u0DEF"], ["\u0E50", "\u0E59"], ["\u0ED0", "\u0ED9"], ["\u0F20", "\u0F29"], ["\u1040", "\u1049"], ["\u1090", "\u1099"], ["\u17E0", "\u17E9"], ["\u1810", "\u1819"], ["\u1946", "\u194F"], ["\u19D0", "\u19D9"], ["\u1A80", "\u1A89"], ["\u1A90", "\u1A99"], ["\u1B50", "\u1B59"], ["\u1BB0", "\u1BB9"], ["\u1C40", "\u1C49"], ["\u1C50", "\u1C59"], ["\uA620", "\uA629"], ["\uA8D0", "\uA8D9"], ["\uA900", "\uA909"], ["\uA9D0", "\uA9D9"], ["\uA9F0", "\uA9F9"], ["\uAA50", "\uAA59"], ["\uABF0", "\uABF9"], ["\uFF10", "\uFF19"]], false, false);
+  var peg$c131 = /^[\u16EE-\u16F0\u2160-\u2182\u2185-\u2188\u3007\u3021-\u3029\u3038-\u303A\uA6E6-\uA6EF]/;
+  var peg$c132 = peg$classExpectation([["\u16EE", "\u16F0"], ["\u2160", "\u2182"], ["\u2185", "\u2188"], "\u3007", ["\u3021", "\u3029"], ["\u3038", "\u303A"], ["\uA6E6", "\uA6EF"]], false, false);
+  var peg$c133 = /^[_\u203F-\u2040\u2054\uFE33-\uFE34\uFE4D-\uFE4F\uFF3F]/;
+  var peg$c134 = peg$classExpectation(["_", ["\u203F", "\u2040"], "\u2054", ["\uFE33", "\uFE34"], ["\uFE4D", "\uFE4F"], "\uFF3F"], false, false);
+  var peg$c135 = /^[ \xA0\u1680\u2000-\u200A\u202F\u205F\u3000]/;
+  var peg$c136 = "break";
+  var peg$c137 = peg$literalExpectation("break", false);
+  var peg$c138 = "case";
+  var peg$c139 = peg$literalExpectation("case", false);
+  var peg$c140 = "catch";
+  var peg$c141 = peg$literalExpectation("catch", false);
+  var peg$c142 = "class";
+  var peg$c143 = peg$literalExpectation("class", false);
+  var peg$c144 = "const";
+  var peg$c145 = peg$literalExpectation("const", false);
+  var peg$c146 = "continue";
+  var peg$c147 = peg$literalExpectation("continue", false);
+  var peg$c148 = "debugger";
+  var peg$c149 = peg$literalExpectation("debugger", false);
+  var peg$c150 = "default";
+  var peg$c151 = peg$literalExpectation("default", false);
+  var peg$c152 = "delete";
+  var peg$c153 = peg$literalExpectation("delete", false);
+  var peg$c154 = "do";
+  var peg$c155 = peg$literalExpectation("do", false);
+  var peg$c156 = "else";
+  var peg$c157 = peg$literalExpectation("else", false);
+  var peg$c158 = "enum";
+  var peg$c159 = peg$literalExpectation("enum", false);
+  var peg$c160 = "export";
+  var peg$c161 = peg$literalExpectation("export", false);
+  var peg$c162 = "extends";
+  var peg$c163 = peg$literalExpectation("extends", false);
+  var peg$c164 = "false";
+  var peg$c165 = peg$literalExpectation("false", false);
+  var peg$c166 = "finally";
+  var peg$c167 = peg$literalExpectation("finally", false);
+  var peg$c168 = "for";
+  var peg$c169 = peg$literalExpectation("for", false);
+  var peg$c170 = "function";
+  var peg$c171 = peg$literalExpectation("function", false);
+  var peg$c172 = "if";
+  var peg$c173 = peg$literalExpectation("if", false);
+  var peg$c174 = "import";
+  var peg$c175 = peg$literalExpectation("import", false);
+  var peg$c176 = "instanceof";
+  var peg$c177 = peg$literalExpectation("instanceof", false);
+  var peg$c178 = "in";
+  var peg$c179 = peg$literalExpectation("in", false);
+  var peg$c180 = "new";
+  var peg$c181 = peg$literalExpectation("new", false);
+  var peg$c182 = "null";
+  var peg$c183 = peg$literalExpectation("null", false);
+  var peg$c184 = "return";
+  var peg$c185 = peg$literalExpectation("return", false);
+  var peg$c186 = "super";
+  var peg$c187 = peg$literalExpectation("super", false);
+  var peg$c188 = "switch";
+  var peg$c189 = peg$literalExpectation("switch", false);
+  var peg$c190 = "this";
+  var peg$c191 = peg$literalExpectation("this", false);
+  var peg$c192 = "throw";
+  var peg$c193 = peg$literalExpectation("throw", false);
+  var peg$c194 = "true";
+  var peg$c195 = peg$literalExpectation("true", false);
+  var peg$c196 = "try";
+  var peg$c197 = peg$literalExpectation("try", false);
+  var peg$c198 = "typeof";
+  var peg$c199 = peg$literalExpectation("typeof", false);
+  var peg$c200 = "var";
+  var peg$c201 = peg$literalExpectation("var", false);
+  var peg$c202 = "void";
+  var peg$c203 = peg$literalExpectation("void", false);
+  var peg$c204 = "while";
+  var peg$c205 = peg$literalExpectation("while", false);
+  var peg$c206 = "with";
+  var peg$c207 = peg$literalExpectation("with", false);
+  var peg$c208 = ";";
+  var peg$c209 = peg$literalExpectation(";", false);
 
   var peg$currPos = 0;
   var peg$savedPos = 0;
@@ -1421,7 +1390,6 @@ function peg$parse(input, options) {
 
     if (peg$silentFails === 0) { peg$expect(peg$c35); }
     peg$silentFails++;
-    if (peg$silentFails === 0) { peg$expect(peg$c37); }
     if (input.charCodeAt(peg$currPos) === 9) {
       s0 = peg$c36;
       peg$currPos++;
@@ -1429,41 +1397,36 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$expect(peg$c39); }
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c38;
+        s0 = peg$c37;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
       }
       if (s0 === peg$FAILED) {
-        if (peg$silentFails === 0) { peg$expect(peg$c41); }
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c40;
+          s0 = peg$c38;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
         }
         if (s0 === peg$FAILED) {
-          if (peg$silentFails === 0) { peg$expect(peg$c43); }
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c42;
+            s0 = peg$c39;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
           }
           if (s0 === peg$FAILED) {
-            if (peg$silentFails === 0) { peg$expect(peg$c45); }
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c44;
+              s0 = peg$c40;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
             }
             if (s0 === peg$FAILED) {
-              if (peg$silentFails === 0) { peg$expect(peg$c47); }
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c46;
+                s0 = peg$c41;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
@@ -1484,8 +1447,8 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c49); }
-    if (peg$c48.test(input.charAt(peg$currPos))) {
+    if (peg$silentFails === 0) { peg$expect(peg$c43); }
+    if (peg$c42.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
@@ -1498,43 +1461,38 @@ function peg$parse(input, options) {
   function peg$parseLineTerminatorSequence() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c50); }
+    if (peg$silentFails === 0) { peg$expect(peg$c44); }
     peg$silentFails++;
-    if (peg$silentFails === 0) { peg$expect(peg$c52); }
     if (input.charCodeAt(peg$currPos) === 10) {
-      s0 = peg$c51;
+      s0 = peg$c45;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$expect(peg$c54); }
-      if (input.substr(peg$currPos, 2) === peg$c53) {
-        s0 = peg$c53;
+      if (input.substr(peg$currPos, 2) === peg$c46) {
+        s0 = peg$c46;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
       }
       if (s0 === peg$FAILED) {
-        if (peg$silentFails === 0) { peg$expect(peg$c56); }
         if (input.charCodeAt(peg$currPos) === 13) {
-          s0 = peg$c55;
+          s0 = peg$c47;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
         }
         if (s0 === peg$FAILED) {
-          if (peg$silentFails === 0) { peg$expect(peg$c58); }
           if (input.charCodeAt(peg$currPos) === 8232) {
-            s0 = peg$c57;
+            s0 = peg$c48;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
           }
           if (s0 === peg$FAILED) {
-            if (peg$silentFails === 0) { peg$expect(peg$c60); }
             if (input.charCodeAt(peg$currPos) === 8233) {
-              s0 = peg$c59;
+              s0 = peg$c49;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
@@ -1551,7 +1509,7 @@ function peg$parse(input, options) {
   function peg$parseComment() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c61); }
+    if (peg$silentFails === 0) { peg$expect(peg$c50); }
     peg$silentFails++;
     s0 = peg$parseMultiLineComment();
     if (s0 === peg$FAILED) {
@@ -1566,9 +1524,8 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c63); }
-    if (input.substr(peg$currPos, 2) === peg$c62) {
-      s1 = peg$c62;
+    if (input.substr(peg$currPos, 2) === peg$c51) {
+      s1 = peg$c51;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
@@ -1578,9 +1535,8 @@ function peg$parse(input, options) {
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$begin();
-      if (peg$silentFails === 0) { peg$expect(peg$c65); }
-      if (input.substr(peg$currPos, 2) === peg$c64) {
-        s5 = peg$c64;
+      if (input.substr(peg$currPos, 2) === peg$c52) {
+        s5 = peg$c52;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
@@ -1610,9 +1566,8 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$begin();
-        if (peg$silentFails === 0) { peg$expect(peg$c65); }
-        if (input.substr(peg$currPos, 2) === peg$c64) {
-          s5 = peg$c64;
+        if (input.substr(peg$currPos, 2) === peg$c52) {
+          s5 = peg$c52;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
@@ -1639,9 +1594,8 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$silentFails === 0) { peg$expect(peg$c65); }
-        if (input.substr(peg$currPos, 2) === peg$c64) {
-          s3 = peg$c64;
+        if (input.substr(peg$currPos, 2) === peg$c52) {
+          s3 = peg$c52;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
@@ -1669,9 +1623,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c63); }
-    if (input.substr(peg$currPos, 2) === peg$c62) {
-      s1 = peg$c62;
+    if (peg$silentFails === 0) { peg$expect(peg$c53); }
+    if (input.substr(peg$currPos, 2) === peg$c51) {
+      s1 = peg$c51;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
@@ -1681,9 +1635,9 @@ function peg$parse(input, options) {
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$begin();
-      if (peg$silentFails === 0) { peg$expect(peg$c65); }
-      if (input.substr(peg$currPos, 2) === peg$c64) {
-        s5 = peg$c64;
+      if (peg$silentFails === 0) { peg$expect(peg$c54); }
+      if (input.substr(peg$currPos, 2) === peg$c52) {
+        s5 = peg$c52;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
@@ -1716,9 +1670,9 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$begin();
-        if (peg$silentFails === 0) { peg$expect(peg$c65); }
-        if (input.substr(peg$currPos, 2) === peg$c64) {
-          s5 = peg$c64;
+        if (peg$silentFails === 0) { peg$expect(peg$c54); }
+        if (input.substr(peg$currPos, 2) === peg$c52) {
+          s5 = peg$c52;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
@@ -1748,9 +1702,9 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (peg$silentFails === 0) { peg$expect(peg$c65); }
-        if (input.substr(peg$currPos, 2) === peg$c64) {
-          s3 = peg$c64;
+        if (peg$silentFails === 0) { peg$expect(peg$c54); }
+        if (input.substr(peg$currPos, 2) === peg$c52) {
+          s3 = peg$c52;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
@@ -1778,9 +1732,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c67); }
-    if (input.substr(peg$currPos, 2) === peg$c66) {
-      s1 = peg$c66;
+    if (peg$silentFails === 0) { peg$expect(peg$c56); }
+    if (input.substr(peg$currPos, 2) === peg$c55) {
+      s1 = peg$c55;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
@@ -1871,7 +1825,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIdentifierName();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$c68(s2);
+        s0 = peg$c57(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1887,7 +1841,7 @@ function peg$parse(input, options) {
   function peg$parseIdentifierName() {
     var s0, s1, s2, s3;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c69); }
+    if (peg$silentFails === 0) { peg$expect(peg$c58); }
     peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parseIdentifierStart();
@@ -1900,7 +1854,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$c70(s1, s2);
+        s0 = peg$c59(s1, s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1927,18 +1881,18 @@ function peg$parse(input, options) {
         s0 = peg$FAILED;
       }
       if (s0 === peg$FAILED) {
-        if (peg$silentFails === 0) { peg$expect(peg$c72); }
+        if (peg$silentFails === 0) { peg$expect(peg$c61); }
         if (input.charCodeAt(peg$currPos) === 95) {
-          s0 = peg$c71;
+          s0 = peg$c60;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (peg$silentFails === 0) { peg$expect(peg$c74); }
+          if (peg$silentFails === 0) { peg$expect(peg$c63); }
           if (input.charCodeAt(peg$currPos) === 92) {
-            s1 = peg$c73;
+            s1 = peg$c62;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
@@ -1947,7 +1901,7 @@ function peg$parse(input, options) {
             s2 = peg$parseUnicodeEscapeSequence();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$c75(s2);
+              s0 = peg$c64(s2);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -1974,17 +1928,17 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$parsePc();
           if (s0 === peg$FAILED) {
-            if (peg$silentFails === 0) { peg$expect(peg$c77); }
+            if (peg$silentFails === 0) { peg$expect(peg$c66); }
             if (input.charCodeAt(peg$currPos) === 8204) {
-              s0 = peg$c76;
+              s0 = peg$c65;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
             }
             if (s0 === peg$FAILED) {
-              if (peg$silentFails === 0) { peg$expect(peg$c79); }
+              if (peg$silentFails === 0) { peg$expect(peg$c68); }
               if (input.charCodeAt(peg$currPos) === 8205) {
-                s0 = peg$c78;
+                s0 = peg$c67;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
@@ -2172,14 +2126,13 @@ function peg$parse(input, options) {
   function peg$parseLiteralMatcher() {
     var s0, s1, s2;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c80); }
+    if (peg$silentFails === 0) { peg$expect(peg$c69); }
     peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parseStringLiteral();
     if (s1 !== peg$FAILED) {
-      if (peg$silentFails === 0) { peg$expect(peg$c82); }
       if (input.charCodeAt(peg$currPos) === 105) {
-        s2 = peg$c81;
+        s2 = peg$c70;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
@@ -2189,7 +2142,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$c83(s1, s2);
+        s0 = peg$c71(s1, s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2206,12 +2159,11 @@ function peg$parse(input, options) {
   function peg$parseStringLiteral() {
     var s0, s1, s2, s3;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c84); }
+    if (peg$silentFails === 0) { peg$expect(peg$c72); }
     peg$silentFails++;
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c86); }
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c85;
+      s1 = peg$c73;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
@@ -2224,16 +2176,15 @@ function peg$parse(input, options) {
         s3 = peg$parseDoubleStringCharacter();
       }
       if (s2 !== peg$FAILED) {
-        if (peg$silentFails === 0) { peg$expect(peg$c86); }
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c85;
+          s3 = peg$c73;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$c87(s2);
+          s0 = peg$c74(s2);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2248,9 +2199,8 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (peg$silentFails === 0) { peg$expect(peg$c89); }
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c88;
+        s1 = peg$c75;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
@@ -2263,16 +2213,15 @@ function peg$parse(input, options) {
           s3 = peg$parseSingleStringCharacter();
         }
         if (s2 !== peg$FAILED) {
-          if (peg$silentFails === 0) { peg$expect(peg$c89); }
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c88;
+            s3 = peg$c75;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s0 = peg$c87(s2);
+            s0 = peg$c74(s2);
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -2297,17 +2246,15 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$begin();
-    if (peg$silentFails === 0) { peg$expect(peg$c86); }
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c85;
+      s2 = peg$c73;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
     }
     if (s2 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$expect(peg$c74); }
       if (input.charCodeAt(peg$currPos) === 92) {
-        s2 = peg$c73;
+        s2 = peg$c62;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
@@ -2327,7 +2274,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSourceCharacter();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$c90();
+        s0 = peg$c76();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2338,9 +2285,8 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (peg$silentFails === 0) { peg$expect(peg$c74); }
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c73;
+        s1 = peg$c62;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
@@ -2349,7 +2295,7 @@ function peg$parse(input, options) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$c75(s2);
+          s0 = peg$c64(s2);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2372,17 +2318,15 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$begin();
-    if (peg$silentFails === 0) { peg$expect(peg$c89); }
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c88;
+      s2 = peg$c75;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
     }
     if (s2 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$expect(peg$c74); }
       if (input.charCodeAt(peg$currPos) === 92) {
-        s2 = peg$c73;
+        s2 = peg$c62;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
@@ -2402,7 +2346,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSourceCharacter();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$c90();
+        s0 = peg$c76();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2413,9 +2357,8 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (peg$silentFails === 0) { peg$expect(peg$c74); }
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c73;
+        s1 = peg$c62;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
@@ -2424,7 +2367,7 @@ function peg$parse(input, options) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$c75(s2);
+          s0 = peg$c64(s2);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2444,20 +2387,18 @@ function peg$parse(input, options) {
   function peg$parseCharacterClassMatcher() {
     var s0, s1, s2, s3, s4, s5;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c91); }
+    if (peg$silentFails === 0) { peg$expect(peg$c77); }
     peg$silentFails++;
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c93); }
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c92;
+      s1 = peg$c78;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
-      if (peg$silentFails === 0) { peg$expect(peg$c95); }
       if (input.charCodeAt(peg$currPos) === 94) {
-        s2 = peg$c94;
+        s2 = peg$c79;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
@@ -2479,17 +2420,15 @@ function peg$parse(input, options) {
           }
         }
         if (s3 !== peg$FAILED) {
-          if (peg$silentFails === 0) { peg$expect(peg$c97); }
           if (input.charCodeAt(peg$currPos) === 93) {
-            s4 = peg$c96;
+            s4 = peg$c80;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
           }
           if (s4 !== peg$FAILED) {
-            if (peg$silentFails === 0) { peg$expect(peg$c82); }
             if (input.charCodeAt(peg$currPos) === 105) {
-              s5 = peg$c81;
+              s5 = peg$c70;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
@@ -2499,7 +2438,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$c98(s2, s3, s5);
+              s0 = peg$c81(s2, s3, s5);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -2531,9 +2470,8 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseClassCharacter();
     if (s1 !== peg$FAILED) {
-      if (peg$silentFails === 0) { peg$expect(peg$c100); }
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c99;
+        s2 = peg$c82;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
@@ -2542,7 +2480,7 @@ function peg$parse(input, options) {
         s3 = peg$parseClassCharacter();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$c101(s1, s3);
+          s0 = peg$c83(s1, s3);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2565,17 +2503,15 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$begin();
-    if (peg$silentFails === 0) { peg$expect(peg$c97); }
     if (input.charCodeAt(peg$currPos) === 93) {
-      s2 = peg$c96;
+      s2 = peg$c80;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
     }
     if (s2 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$expect(peg$c74); }
       if (input.charCodeAt(peg$currPos) === 92) {
-        s2 = peg$c73;
+        s2 = peg$c62;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
@@ -2595,7 +2531,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSourceCharacter();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$c90();
+        s0 = peg$c76();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2606,9 +2542,8 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (peg$silentFails === 0) { peg$expect(peg$c74); }
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c73;
+        s1 = peg$c62;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
@@ -2617,7 +2552,7 @@ function peg$parse(input, options) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$c75(s2);
+          s0 = peg$c64(s2);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2638,9 +2573,8 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c74); }
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c73;
+      s1 = peg$c62;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
@@ -2649,7 +2583,7 @@ function peg$parse(input, options) {
       s2 = peg$parseLineTerminatorSequence();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$c102();
+        s0 = peg$c84();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2668,9 +2602,8 @@ function peg$parse(input, options) {
     s0 = peg$parseCharacterEscapeSequence();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (peg$silentFails === 0) { peg$expect(peg$c104); }
       if (input.charCodeAt(peg$currPos) === 48) {
-        s1 = peg$c103;
+        s1 = peg$c85;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
@@ -2688,7 +2621,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$c105();
+          s0 = peg$c86();
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2722,111 +2655,102 @@ function peg$parse(input, options) {
   function peg$parseSingleEscapeCharacter() {
     var s0, s1;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c89); }
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c88;
+      s0 = peg$c75;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$expect(peg$c86); }
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c85;
+        s0 = peg$c73;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
       }
       if (s0 === peg$FAILED) {
-        if (peg$silentFails === 0) { peg$expect(peg$c74); }
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c73;
+          s0 = peg$c62;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (peg$silentFails === 0) { peg$expect(peg$c107); }
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c106;
+            s1 = peg$c87;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c108();
+            s1 = peg$c88();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (peg$silentFails === 0) { peg$expect(peg$c110); }
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c109;
+              s1 = peg$c89;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c111();
+              s1 = peg$c90();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              if (peg$silentFails === 0) { peg$expect(peg$c113); }
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c112;
+                s1 = peg$c91;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c114();
+                s1 = peg$c92();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                if (peg$silentFails === 0) { peg$expect(peg$c116); }
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c115;
+                  s1 = peg$c93;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c117();
+                  s1 = peg$c94();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
-                  if (peg$silentFails === 0) { peg$expect(peg$c119); }
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c118;
+                    s1 = peg$c95;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c120();
+                    s1 = peg$c96();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
-                    if (peg$silentFails === 0) { peg$expect(peg$c122); }
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c121;
+                      s1 = peg$c97;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c123();
+                      s1 = peg$c98();
                     }
                     s0 = s1;
                   }
@@ -2862,7 +2786,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSourceCharacter();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$c90();
+        s0 = peg$c76();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2882,17 +2806,15 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$parseDecimalDigit();
       if (s0 === peg$FAILED) {
-        if (peg$silentFails === 0) { peg$expect(peg$c125); }
         if (input.charCodeAt(peg$currPos) === 120) {
-          s0 = peg$c124;
+          s0 = peg$c99;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
         }
         if (s0 === peg$FAILED) {
-          if (peg$silentFails === 0) { peg$expect(peg$c127); }
           if (input.charCodeAt(peg$currPos) === 117) {
-            s0 = peg$c126;
+            s0 = peg$c100;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
@@ -2908,9 +2830,8 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c125); }
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c124;
+      s1 = peg$c99;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
@@ -2939,7 +2860,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$c128(s2);
+        s0 = peg$c101(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2956,9 +2877,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c127); }
+    if (peg$silentFails === 0) { peg$expect(peg$c102); }
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c126;
+      s1 = peg$c100;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
@@ -2999,7 +2920,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$c128(s2);
+        s0 = peg$c101(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -3015,8 +2936,7 @@ function peg$parse(input, options) {
   function peg$parseDecimalDigit() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c130); }
-    if (peg$c129.test(input.charAt(peg$currPos))) {
+    if (peg$c103.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
@@ -3029,8 +2949,8 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c132); }
-    if (peg$c131.test(input.charAt(peg$currPos))) {
+    if (peg$silentFails === 0) { peg$expect(peg$c105); }
+    if (peg$c104.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
@@ -3044,16 +2964,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c134); }
+    if (peg$silentFails === 0) { peg$expect(peg$c107); }
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c133;
+      s1 = peg$c106;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c135();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -3063,12 +2983,11 @@ function peg$parse(input, options) {
   function peg$parseCodeBlock() {
     var s0, s1, s2, s3;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c136); }
+    if (peg$silentFails === 0) { peg$expect(peg$c109); }
     peg$silentFails++;
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c138); }
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c137;
+      s1 = peg$c110;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
@@ -3076,16 +2995,15 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parseCode();
       if (s2 !== peg$FAILED) {
-        if (peg$silentFails === 0) { peg$expect(peg$c140); }
         if (input.charCodeAt(peg$currPos) === 125) {
-          s3 = peg$c139;
+          s3 = peg$c111;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$c141(s2);
+          s0 = peg$c112(s2);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -3100,16 +3018,15 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (peg$silentFails === 0) { peg$expect(peg$c138); }
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c137;
+        s1 = peg$c110;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c142();
+        s1 = peg$c113();
       }
       s0 = s1;
     }
@@ -3127,8 +3044,7 @@ function peg$parse(input, options) {
     s3 = peg$currPos;
     s4 = peg$currPos;
     peg$begin();
-    if (peg$silentFails === 0) { peg$expect(peg$c144); }
-    if (peg$c143.test(input.charAt(peg$currPos))) {
+    if (peg$c114.test(input.charAt(peg$currPos))) {
       s5 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
@@ -3160,8 +3076,7 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$begin();
-        if (peg$silentFails === 0) { peg$expect(peg$c144); }
-        if (peg$c143.test(input.charAt(peg$currPos))) {
+        if (peg$c114.test(input.charAt(peg$currPos))) {
           s5 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
@@ -3193,9 +3108,8 @@ function peg$parse(input, options) {
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
-      if (peg$silentFails === 0) { peg$expect(peg$c138); }
       if (input.charCodeAt(peg$currPos) === 123) {
-        s3 = peg$c137;
+        s3 = peg$c110;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
@@ -3203,9 +3117,8 @@ function peg$parse(input, options) {
       if (s3 !== peg$FAILED) {
         s4 = peg$parseCode();
         if (s4 !== peg$FAILED) {
-          if (peg$silentFails === 0) { peg$expect(peg$c140); }
           if (input.charCodeAt(peg$currPos) === 125) {
-            s5 = peg$c139;
+            s5 = peg$c111;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
@@ -3232,8 +3145,7 @@ function peg$parse(input, options) {
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$begin();
-      if (peg$silentFails === 0) { peg$expect(peg$c144); }
-      if (peg$c143.test(input.charAt(peg$currPos))) {
+      if (peg$c114.test(input.charAt(peg$currPos))) {
         s5 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
@@ -3265,8 +3177,7 @@ function peg$parse(input, options) {
           s3 = peg$currPos;
           s4 = peg$currPos;
           peg$begin();
-          if (peg$silentFails === 0) { peg$expect(peg$c144); }
-          if (peg$c143.test(input.charAt(peg$currPos))) {
+          if (peg$c114.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
@@ -3298,9 +3209,8 @@ function peg$parse(input, options) {
       }
       if (s2 === peg$FAILED) {
         s2 = peg$currPos;
-        if (peg$silentFails === 0) { peg$expect(peg$c138); }
         if (input.charCodeAt(peg$currPos) === 123) {
-          s3 = peg$c137;
+          s3 = peg$c110;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
@@ -3308,9 +3218,8 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parseCode();
           if (s4 !== peg$FAILED) {
-            if (peg$silentFails === 0) { peg$expect(peg$c140); }
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c139;
+              s5 = peg$c111;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
@@ -3344,8 +3253,8 @@ function peg$parse(input, options) {
   function peg$parseLl() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c146); }
-    if (peg$c145.test(input.charAt(peg$currPos))) {
+    if (peg$silentFails === 0) { peg$expect(peg$c116); }
+    if (peg$c115.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
@@ -3358,8 +3267,8 @@ function peg$parse(input, options) {
   function peg$parseLm() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c148); }
-    if (peg$c147.test(input.charAt(peg$currPos))) {
+    if (peg$silentFails === 0) { peg$expect(peg$c118); }
+    if (peg$c117.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
@@ -3372,8 +3281,8 @@ function peg$parse(input, options) {
   function peg$parseLo() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c150); }
-    if (peg$c149.test(input.charAt(peg$currPos))) {
+    if (peg$silentFails === 0) { peg$expect(peg$c120); }
+    if (peg$c119.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
@@ -3386,8 +3295,8 @@ function peg$parse(input, options) {
   function peg$parseLt() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c152); }
-    if (peg$c151.test(input.charAt(peg$currPos))) {
+    if (peg$silentFails === 0) { peg$expect(peg$c122); }
+    if (peg$c121.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
@@ -3400,8 +3309,8 @@ function peg$parse(input, options) {
   function peg$parseLu() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c154); }
-    if (peg$c153.test(input.charAt(peg$currPos))) {
+    if (peg$silentFails === 0) { peg$expect(peg$c124); }
+    if (peg$c123.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
@@ -3414,8 +3323,8 @@ function peg$parse(input, options) {
   function peg$parseMc() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c156); }
-    if (peg$c155.test(input.charAt(peg$currPos))) {
+    if (peg$silentFails === 0) { peg$expect(peg$c126); }
+    if (peg$c125.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
@@ -3428,8 +3337,8 @@ function peg$parse(input, options) {
   function peg$parseMn() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c158); }
-    if (peg$c157.test(input.charAt(peg$currPos))) {
+    if (peg$silentFails === 0) { peg$expect(peg$c128); }
+    if (peg$c127.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
@@ -3442,8 +3351,8 @@ function peg$parse(input, options) {
   function peg$parseNd() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c160); }
-    if (peg$c159.test(input.charAt(peg$currPos))) {
+    if (peg$silentFails === 0) { peg$expect(peg$c130); }
+    if (peg$c129.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
@@ -3456,8 +3365,8 @@ function peg$parse(input, options) {
   function peg$parseNl() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c162); }
-    if (peg$c161.test(input.charAt(peg$currPos))) {
+    if (peg$silentFails === 0) { peg$expect(peg$c132); }
+    if (peg$c131.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
@@ -3470,8 +3379,8 @@ function peg$parse(input, options) {
   function peg$parsePc() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c164); }
-    if (peg$c163.test(input.charAt(peg$currPos))) {
+    if (peg$silentFails === 0) { peg$expect(peg$c134); }
+    if (peg$c133.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
@@ -3484,8 +3393,7 @@ function peg$parse(input, options) {
   function peg$parseZs() {
     var s0;
 
-    if (peg$silentFails === 0) { peg$expect(peg$c166); }
-    if (peg$c165.test(input.charAt(peg$currPos))) {
+    if (peg$c135.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
@@ -3499,9 +3407,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c168); }
-    if (input.substr(peg$currPos, 5) === peg$c167) {
-      s1 = peg$c167;
+    if (peg$silentFails === 0) { peg$expect(peg$c137); }
+    if (input.substr(peg$currPos, 5) === peg$c136) {
+      s1 = peg$c136;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
@@ -3536,9 +3444,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c170); }
-    if (input.substr(peg$currPos, 4) === peg$c169) {
-      s1 = peg$c169;
+    if (peg$silentFails === 0) { peg$expect(peg$c139); }
+    if (input.substr(peg$currPos, 4) === peg$c138) {
+      s1 = peg$c138;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
@@ -3573,9 +3481,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c172); }
-    if (input.substr(peg$currPos, 5) === peg$c171) {
-      s1 = peg$c171;
+    if (peg$silentFails === 0) { peg$expect(peg$c141); }
+    if (input.substr(peg$currPos, 5) === peg$c140) {
+      s1 = peg$c140;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
@@ -3610,9 +3518,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c174); }
-    if (input.substr(peg$currPos, 5) === peg$c173) {
-      s1 = peg$c173;
+    if (peg$silentFails === 0) { peg$expect(peg$c143); }
+    if (input.substr(peg$currPos, 5) === peg$c142) {
+      s1 = peg$c142;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
@@ -3647,9 +3555,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c176); }
-    if (input.substr(peg$currPos, 5) === peg$c175) {
-      s1 = peg$c175;
+    if (peg$silentFails === 0) { peg$expect(peg$c145); }
+    if (input.substr(peg$currPos, 5) === peg$c144) {
+      s1 = peg$c144;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
@@ -3684,9 +3592,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c178); }
-    if (input.substr(peg$currPos, 8) === peg$c177) {
-      s1 = peg$c177;
+    if (peg$silentFails === 0) { peg$expect(peg$c147); }
+    if (input.substr(peg$currPos, 8) === peg$c146) {
+      s1 = peg$c146;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
@@ -3721,9 +3629,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c180); }
-    if (input.substr(peg$currPos, 8) === peg$c179) {
-      s1 = peg$c179;
+    if (peg$silentFails === 0) { peg$expect(peg$c149); }
+    if (input.substr(peg$currPos, 8) === peg$c148) {
+      s1 = peg$c148;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
@@ -3758,9 +3666,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c182); }
-    if (input.substr(peg$currPos, 7) === peg$c181) {
-      s1 = peg$c181;
+    if (peg$silentFails === 0) { peg$expect(peg$c151); }
+    if (input.substr(peg$currPos, 7) === peg$c150) {
+      s1 = peg$c150;
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
@@ -3795,9 +3703,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c184); }
-    if (input.substr(peg$currPos, 6) === peg$c183) {
-      s1 = peg$c183;
+    if (peg$silentFails === 0) { peg$expect(peg$c153); }
+    if (input.substr(peg$currPos, 6) === peg$c152) {
+      s1 = peg$c152;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
@@ -3832,9 +3740,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c186); }
-    if (input.substr(peg$currPos, 2) === peg$c185) {
-      s1 = peg$c185;
+    if (peg$silentFails === 0) { peg$expect(peg$c155); }
+    if (input.substr(peg$currPos, 2) === peg$c154) {
+      s1 = peg$c154;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
@@ -3869,9 +3777,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c188); }
-    if (input.substr(peg$currPos, 4) === peg$c187) {
-      s1 = peg$c187;
+    if (peg$silentFails === 0) { peg$expect(peg$c157); }
+    if (input.substr(peg$currPos, 4) === peg$c156) {
+      s1 = peg$c156;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
@@ -3906,9 +3814,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c190); }
-    if (input.substr(peg$currPos, 4) === peg$c189) {
-      s1 = peg$c189;
+    if (peg$silentFails === 0) { peg$expect(peg$c159); }
+    if (input.substr(peg$currPos, 4) === peg$c158) {
+      s1 = peg$c158;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
@@ -3943,9 +3851,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c192); }
-    if (input.substr(peg$currPos, 6) === peg$c191) {
-      s1 = peg$c191;
+    if (peg$silentFails === 0) { peg$expect(peg$c161); }
+    if (input.substr(peg$currPos, 6) === peg$c160) {
+      s1 = peg$c160;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
@@ -3980,9 +3888,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c194); }
-    if (input.substr(peg$currPos, 7) === peg$c193) {
-      s1 = peg$c193;
+    if (peg$silentFails === 0) { peg$expect(peg$c163); }
+    if (input.substr(peg$currPos, 7) === peg$c162) {
+      s1 = peg$c162;
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
@@ -4017,9 +3925,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c196); }
-    if (input.substr(peg$currPos, 5) === peg$c195) {
-      s1 = peg$c195;
+    if (peg$silentFails === 0) { peg$expect(peg$c165); }
+    if (input.substr(peg$currPos, 5) === peg$c164) {
+      s1 = peg$c164;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
@@ -4054,9 +3962,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c198); }
-    if (input.substr(peg$currPos, 7) === peg$c197) {
-      s1 = peg$c197;
+    if (peg$silentFails === 0) { peg$expect(peg$c167); }
+    if (input.substr(peg$currPos, 7) === peg$c166) {
+      s1 = peg$c166;
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
@@ -4091,9 +3999,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c200); }
-    if (input.substr(peg$currPos, 3) === peg$c199) {
-      s1 = peg$c199;
+    if (peg$silentFails === 0) { peg$expect(peg$c169); }
+    if (input.substr(peg$currPos, 3) === peg$c168) {
+      s1 = peg$c168;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
@@ -4128,9 +4036,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c202); }
-    if (input.substr(peg$currPos, 8) === peg$c201) {
-      s1 = peg$c201;
+    if (peg$silentFails === 0) { peg$expect(peg$c171); }
+    if (input.substr(peg$currPos, 8) === peg$c170) {
+      s1 = peg$c170;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
@@ -4165,9 +4073,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c204); }
-    if (input.substr(peg$currPos, 2) === peg$c203) {
-      s1 = peg$c203;
+    if (peg$silentFails === 0) { peg$expect(peg$c173); }
+    if (input.substr(peg$currPos, 2) === peg$c172) {
+      s1 = peg$c172;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
@@ -4202,9 +4110,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c206); }
-    if (input.substr(peg$currPos, 6) === peg$c205) {
-      s1 = peg$c205;
+    if (peg$silentFails === 0) { peg$expect(peg$c175); }
+    if (input.substr(peg$currPos, 6) === peg$c174) {
+      s1 = peg$c174;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
@@ -4239,9 +4147,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c208); }
-    if (input.substr(peg$currPos, 10) === peg$c207) {
-      s1 = peg$c207;
+    if (peg$silentFails === 0) { peg$expect(peg$c177); }
+    if (input.substr(peg$currPos, 10) === peg$c176) {
+      s1 = peg$c176;
       peg$currPos += 10;
     } else {
       s1 = peg$FAILED;
@@ -4276,9 +4184,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c210); }
-    if (input.substr(peg$currPos, 2) === peg$c209) {
-      s1 = peg$c209;
+    if (peg$silentFails === 0) { peg$expect(peg$c179); }
+    if (input.substr(peg$currPos, 2) === peg$c178) {
+      s1 = peg$c178;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
@@ -4313,9 +4221,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c212); }
-    if (input.substr(peg$currPos, 3) === peg$c211) {
-      s1 = peg$c211;
+    if (peg$silentFails === 0) { peg$expect(peg$c181); }
+    if (input.substr(peg$currPos, 3) === peg$c180) {
+      s1 = peg$c180;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
@@ -4350,9 +4258,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c214); }
-    if (input.substr(peg$currPos, 4) === peg$c213) {
-      s1 = peg$c213;
+    if (peg$silentFails === 0) { peg$expect(peg$c183); }
+    if (input.substr(peg$currPos, 4) === peg$c182) {
+      s1 = peg$c182;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
@@ -4387,9 +4295,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c216); }
-    if (input.substr(peg$currPos, 6) === peg$c215) {
-      s1 = peg$c215;
+    if (peg$silentFails === 0) { peg$expect(peg$c185); }
+    if (input.substr(peg$currPos, 6) === peg$c184) {
+      s1 = peg$c184;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
@@ -4424,9 +4332,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c218); }
-    if (input.substr(peg$currPos, 5) === peg$c217) {
-      s1 = peg$c217;
+    if (peg$silentFails === 0) { peg$expect(peg$c187); }
+    if (input.substr(peg$currPos, 5) === peg$c186) {
+      s1 = peg$c186;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
@@ -4461,9 +4369,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c220); }
-    if (input.substr(peg$currPos, 6) === peg$c219) {
-      s1 = peg$c219;
+    if (peg$silentFails === 0) { peg$expect(peg$c189); }
+    if (input.substr(peg$currPos, 6) === peg$c188) {
+      s1 = peg$c188;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
@@ -4498,9 +4406,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c222); }
-    if (input.substr(peg$currPos, 4) === peg$c221) {
-      s1 = peg$c221;
+    if (peg$silentFails === 0) { peg$expect(peg$c191); }
+    if (input.substr(peg$currPos, 4) === peg$c190) {
+      s1 = peg$c190;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
@@ -4535,9 +4443,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c224); }
-    if (input.substr(peg$currPos, 5) === peg$c223) {
-      s1 = peg$c223;
+    if (peg$silentFails === 0) { peg$expect(peg$c193); }
+    if (input.substr(peg$currPos, 5) === peg$c192) {
+      s1 = peg$c192;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
@@ -4572,9 +4480,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c226); }
-    if (input.substr(peg$currPos, 4) === peg$c225) {
-      s1 = peg$c225;
+    if (peg$silentFails === 0) { peg$expect(peg$c195); }
+    if (input.substr(peg$currPos, 4) === peg$c194) {
+      s1 = peg$c194;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
@@ -4609,9 +4517,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c228); }
-    if (input.substr(peg$currPos, 3) === peg$c227) {
-      s1 = peg$c227;
+    if (peg$silentFails === 0) { peg$expect(peg$c197); }
+    if (input.substr(peg$currPos, 3) === peg$c196) {
+      s1 = peg$c196;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
@@ -4646,9 +4554,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c230); }
-    if (input.substr(peg$currPos, 6) === peg$c229) {
-      s1 = peg$c229;
+    if (peg$silentFails === 0) { peg$expect(peg$c199); }
+    if (input.substr(peg$currPos, 6) === peg$c198) {
+      s1 = peg$c198;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
@@ -4683,9 +4591,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c232); }
-    if (input.substr(peg$currPos, 3) === peg$c231) {
-      s1 = peg$c231;
+    if (peg$silentFails === 0) { peg$expect(peg$c201); }
+    if (input.substr(peg$currPos, 3) === peg$c200) {
+      s1 = peg$c200;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
@@ -4720,9 +4628,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c234); }
-    if (input.substr(peg$currPos, 4) === peg$c233) {
-      s1 = peg$c233;
+    if (peg$silentFails === 0) { peg$expect(peg$c203); }
+    if (input.substr(peg$currPos, 4) === peg$c202) {
+      s1 = peg$c202;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
@@ -4757,9 +4665,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c236); }
-    if (input.substr(peg$currPos, 5) === peg$c235) {
-      s1 = peg$c235;
+    if (peg$silentFails === 0) { peg$expect(peg$c205); }
+    if (input.substr(peg$currPos, 5) === peg$c204) {
+      s1 = peg$c204;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
@@ -4794,9 +4702,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$silentFails === 0) { peg$expect(peg$c238); }
-    if (input.substr(peg$currPos, 4) === peg$c237) {
-      s1 = peg$c237;
+    if (peg$silentFails === 0) { peg$expect(peg$c207); }
+    if (input.substr(peg$currPos, 4) === peg$c206) {
+      s1 = peg$c206;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
@@ -4877,9 +4785,9 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      if (peg$silentFails === 0) { peg$expect(peg$c240); }
+      if (peg$silentFails === 0) { peg$expect(peg$c209); }
       if (input.charCodeAt(peg$currPos) === 59) {
-        s2 = peg$c239;
+        s2 = peg$c208;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;

--- a/lib/typings/api.d.ts
+++ b/lib/typings/api.d.ts
@@ -94,6 +94,10 @@ declare namespace peg {
 
                 bytecode?: number[];
 
+                // Added by calc-report-failures pass
+
+                reportFailures?: boolean;
+
             }
 
             interface Named extends INode {
@@ -340,6 +344,7 @@ declare namespace peg {
             namespace transform {
 
                 function removeProxyRules( ast: Grammar, options: ICompilerPassOptions ): void;
+                function calcReportFailures( ast: Grammar, options: ICompilerPassOptions ): void;
 
             }
 

--- a/test/spec/unit/compiler/passes/generate-bytecode.spec.js
+++ b/test/spec/unit/compiler/passes/generate-bytecode.spec.js
@@ -75,14 +75,28 @@ describe( "compiler pass |generateBytecode|", function () {
 
     describe( "for named", function () {
 
-        const grammar = "start 'start' = 'a'";
+        const grammar1 = "start 'start' = .";
+        const grammar2 = "start 'start' = 'a'";
+        const grammar3 = "start 'start' = [a]";
 
         it( "generates correct bytecode", function () {
 
-            expect( pass ).to.changeAST( grammar, bytecodeDetails( [
+            expect( pass ).to.changeAST( grammar1, bytecodeDetails( [
                 23, 0,                        // EXPECT <0>
                 28,                           // SILENT_FAILS_ON
-                23, 2, 18, 1, 2, 1, 22, 1, 3, // <expression>
+                17, 2, 1, 21, 1, 3,           // <expression>
+                29                            // SILENT_FAILS_OFF
+            ] ) );
+            expect( pass ).to.changeAST( grammar2, bytecodeDetails( [
+                23, 0,                        // EXPECT <0>
+                28,                           // SILENT_FAILS_ON
+                18, 1, 2, 1, 22, 1, 3,        // <expression>
+                29                            // SILENT_FAILS_OFF
+            ] ) );
+            expect( pass ).to.changeAST( grammar3, bytecodeDetails( [
+                23, 0,                        // EXPECT <0>
+                28,                           // SILENT_FAILS_ON
+                20, 1, 2, 1, 21, 1, 3,        // <expression>
                 29                            // SILENT_FAILS_OFF
             ] ) );
 
@@ -90,10 +104,16 @@ describe( "compiler pass |generateBytecode|", function () {
 
         it( "defines correct constants", function () {
 
-            expect( pass ).to.changeAST( grammar, constsDetails( [
+            expect( pass ).to.changeAST( grammar1, constsDetails( [
+                "peg$otherExpectation(\"start\")"
+            ] ) );
+            expect( pass ).to.changeAST( grammar2, constsDetails( [
                 "peg$otherExpectation(\"start\")",
-                "\"a\"",
-                "peg$literalExpectation(\"a\", false)"
+                "\"a\""
+            ] ) );
+            expect( pass ).to.changeAST( grammar3, constsDetails( [
+                "peg$otherExpectation(\"start\")",
+                "/^[a]/"
             ] ) );
 
         } );
@@ -452,10 +472,21 @@ describe( "compiler pass |generateBytecode|", function () {
 
     describe( "for group", function () {
 
+        const grammar = "start = ('a')";
+
         it( "generates correct bytecode", function () {
 
-            expect( pass ).to.changeAST( "start = ('a')", bytecodeDetails( [
+            expect( pass ).to.changeAST( grammar, bytecodeDetails( [
                 23, 1, 18, 0, 2, 1, 22, 0, 3   // <expression>
+            ] ) );
+
+        } );
+
+        it( "defines correct constants", function () {
+
+            expect( pass ).to.changeAST( grammar, constsDetails( [
+                "\"a\"",
+                "peg$literalExpectation(\"a\", false)"
             ] ) );
 
         } );

--- a/test/spec/unit/compiler/passes/generate-bytecode.spec.js
+++ b/test/spec/unit/compiler/passes/generate-bytecode.spec.js
@@ -79,42 +79,76 @@ describe( "compiler pass |generateBytecode|", function () {
         const grammar2 = "start 'start' = 'a'";
         const grammar3 = "start 'start' = [a]";
 
-        it( "generates correct bytecode", function () {
+        describe( "when |reportFailures=true|", function () {
 
-            expect( pass ).to.changeAST( grammar1, bytecodeDetails( [
-                23, 0,                        // EXPECT <0>
-                28,                           // SILENT_FAILS_ON
-                17, 2, 1, 21, 1, 3,           // <expression>
-                29                            // SILENT_FAILS_OFF
-            ] ) );
-            expect( pass ).to.changeAST( grammar2, bytecodeDetails( [
-                23, 0,                        // EXPECT <0>
-                28,                           // SILENT_FAILS_ON
-                18, 1, 2, 1, 22, 1, 3,        // <expression>
-                29                            // SILENT_FAILS_OFF
-            ] ) );
-            expect( pass ).to.changeAST( grammar3, bytecodeDetails( [
-                23, 0,                        // EXPECT <0>
-                28,                           // SILENT_FAILS_ON
-                20, 1, 2, 1, 21, 1, 3,        // <expression>
-                29                            // SILENT_FAILS_OFF
-            ] ) );
+            it( "generates correct bytecode", function () {
+
+                expect( pass ).to.changeAST( grammar1, bytecodeDetails( [
+                    23, 0,                        // EXPECT <0>
+                    28,                           // SILENT_FAILS_ON
+                    17, 2, 1, 21, 1, 3,           // <expression>
+                    29                            // SILENT_FAILS_OFF
+                ] ) );
+                expect( pass ).to.changeAST( grammar2, bytecodeDetails( [
+                    23, 0,                        // EXPECT <0>
+                    28,                           // SILENT_FAILS_ON
+                    18, 1, 2, 1, 22, 1, 3,        // <expression>
+                    29                            // SILENT_FAILS_OFF
+                ] ) );
+                expect( pass ).to.changeAST( grammar3, bytecodeDetails( [
+                    23, 0,                        // EXPECT <0>
+                    28,                           // SILENT_FAILS_ON
+                    20, 1, 2, 1, 21, 1, 3,        // <expression>
+                    29                            // SILENT_FAILS_OFF
+                ] ) );
+
+            } );
+
+            it( "defines correct constants", function () {
+
+                expect( pass ).to.changeAST( grammar1, constsDetails( [
+                    "peg$otherExpectation(\"start\")"
+                ] ) );
+                expect( pass ).to.changeAST( grammar2, constsDetails( [
+                    "peg$otherExpectation(\"start\")",
+                    "\"a\""
+                ] ) );
+                expect( pass ).to.changeAST( grammar3, constsDetails( [
+                    "peg$otherExpectation(\"start\")",
+                    "/^[a]/"
+                ] ) );
+
+            } );
 
         } );
 
-        it( "defines correct constants", function () {
+        describe( "when |reportFailures=false|", function () {
 
-            expect( pass ).to.changeAST( grammar1, constsDetails( [
-                "peg$otherExpectation(\"start\")"
-            ] ) );
-            expect( pass ).to.changeAST( grammar2, constsDetails( [
-                "peg$otherExpectation(\"start\")",
-                "\"a\""
-            ] ) );
-            expect( pass ).to.changeAST( grammar3, constsDetails( [
-                "peg$otherExpectation(\"start\")",
-                "/^[a]/"
-            ] ) );
+            it( "generates correct bytecode", function () {
+
+                expect( pass ).to.changeAST( grammar1, bytecodeDetails( [
+                    17, 2, 1, 21, 1, 3,           // <expression>
+                ] ), {}, { reportFailures: false } );
+                expect( pass ).to.changeAST( grammar2, bytecodeDetails( [
+                    18, 0, 2, 1, 22, 0, 3,        // <expression>
+                ] ), {}, { reportFailures: false } );
+                expect( pass ).to.changeAST( grammar3, bytecodeDetails( [
+                    20, 0, 2, 1, 21, 1, 3,        // <expression>
+                ] ), {}, { reportFailures: false } );
+
+            } );
+
+            it( "defines correct constants", function () {
+
+                expect( pass ).to.changeAST( grammar1, constsDetails( [] ), {}, { reportFailures: false } );
+                expect( pass ).to.changeAST( grammar2, constsDetails( [
+                    "\"a\""
+                ] ), {}, { reportFailures: false } );
+                expect( pass ).to.changeAST( grammar3, constsDetails( [
+                    "/^[a]/"
+                ] ), {}, { reportFailures: false } );
+
+            } );
 
         } );
 
@@ -693,73 +727,149 @@ describe( "compiler pass |generateBytecode|", function () {
 
     describe( "for literal", function () {
 
-        describe( "empty", function () {
+        describe( "when |reportFailures=true|", function () {
 
-            const grammar = "start = ''";
+            describe( "empty", function () {
 
-            it( "generates correct bytecode", function () {
+                const grammar = "start = ''";
 
-                expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                    0, 0   // PUSH
-                ] ) );
+                it( "generates correct bytecode", function () {
+
+                    expect( pass ).to.changeAST( grammar, bytecodeDetails( [
+                        0, 0   // PUSH
+                    ] ) );
+
+                } );
+
+                it( "defines correct constants", function () {
+
+                    expect( pass ).to.changeAST( grammar, constsDetails( [ "\"\"" ] ) );
+
+                } );
 
             } );
 
-            it( "defines correct constants", function () {
+            describe( "non-empty case-sensitive", function () {
 
-                expect( pass ).to.changeAST( grammar, constsDetails( [ "\"\"" ] ) );
+                const grammar = "start = 'a'";
+
+                it( "generates correct bytecode", function () {
+
+                    expect( pass ).to.changeAST( grammar, bytecodeDetails( [
+                        23, 1,         // EXPECT <1>
+                        18, 0, 2, 1,   // MATCH_STRING <0>
+                        22, 0,         //   * ACCEPT_STRING
+                        3              //   * PUSH_FAILED
+                    ] ) );
+
+                } );
+
+                it( "defines correct constants", function () {
+
+                    expect( pass ).to.changeAST( grammar, constsDetails( [
+                        "\"a\"",
+                        "peg$literalExpectation(\"a\", false)"
+                    ] ) );
+
+                } );
+
+            } );
+
+            describe( "non-empty case-insensitive", function () {
+
+                const grammar = "start = 'A'i";
+
+                it( "generates correct bytecode", function () {
+
+                    expect( pass ).to.changeAST( grammar, bytecodeDetails( [
+                        23, 1,         // EXPECT <1>
+                        19, 0, 2, 1,   // MATCH_STRING_IC <0>
+                        21, 1,         //   * ACCEPT_N
+                        3              //   * PUSH_FAILED
+                    ] ) );
+
+                } );
+
+                it( "defines correct constants", function () {
+
+                    expect( pass ).to.changeAST( grammar, constsDetails( [
+                        "\"a\"",
+                        "peg$literalExpectation(\"A\", true)"
+                    ] ) );
+
+                } );
 
             } );
 
         } );
 
-        describe( "non-empty case-sensitive", function () {
+        describe( "when |reportFailures=false|", function () {
 
-            const grammar = "start = 'a'";
+            describe( "empty", function () {
 
-            it( "generates correct bytecode", function () {
+                const grammar = "start = ''";
 
-                expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                    23, 1,         // EXPECT <1>
-                    18, 0, 2, 1,   // MATCH_STRING <0>
-                    22, 0,         //   * ACCEPT_STRING
-                    3              //   * PUSH_FAILED
-                ] ) );
+                it( "generates correct bytecode", function () {
 
-            } );
+                    expect( pass ).to.changeAST( grammar, bytecodeDetails( [
+                        0, 0   // PUSH
+                    ] ), {}, { reportFailures: false } );
 
-            it( "defines correct constants", function () {
+                } );
 
-                expect( pass ).to.changeAST( grammar, constsDetails( [
-                    "\"a\"",
-                    "peg$literalExpectation(\"a\", false)"
-                ] ) );
+                it( "defines correct constants", function () {
+
+                    expect( pass ).to.changeAST( grammar, constsDetails( [ "\"\"" ] ), {}, { reportFailures: false } );
+
+                } );
 
             } );
 
-        } );
+            describe( "non-empty case-sensitive", function () {
 
-        describe( "non-empty case-insensitive", function () {
+                const grammar = "start = 'a'";
 
-            const grammar = "start = 'A'i";
+                it( "generates correct bytecode", function () {
 
-            it( "generates correct bytecode", function () {
+                    expect( pass ).to.changeAST( grammar, bytecodeDetails( [
+                        18, 0, 2, 1,   // MATCH_STRING <0>
+                        22, 0,         //   * ACCEPT_STRING
+                        3              //   * PUSH_FAILED
+                    ] ), {}, { reportFailures: false } );
 
-                expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                    23, 1,         // EXPECT <1>
-                    19, 0, 2, 1,   // MATCH_STRING_IC <0>
-                    21, 1,         //   * ACCEPT_N
-                    3              //   * PUSH_FAILED
-                ] ) );
+                } );
+
+                it( "defines correct constants", function () {
+
+                    expect( pass ).to.changeAST( grammar, constsDetails( [
+                        "\"a\""
+                    ] ), {}, { reportFailures: false } );
+
+                } );
 
             } );
 
-            it( "defines correct constants", function () {
+            describe( "non-empty case-insensitive", function () {
 
-                expect( pass ).to.changeAST( grammar, constsDetails( [
-                    "\"a\"",
-                    "peg$literalExpectation(\"A\", true)"
-                ] ) );
+                const grammar = "start = 'A'i";
+
+                it( "generates correct bytecode", function () {
+
+                    expect( pass ).to.changeAST( grammar, bytecodeDetails( [
+                        19, 0, 2, 1,   // MATCH_STRING_IC <0>
+                        21, 1,         //   * ACCEPT_N
+                        3              //   * PUSH_FAILED
+                    ] ), {}, { reportFailures: false } );
+
+                } );
+
+                it( "defines correct constants", function () {
+
+                    expect( pass ).to.changeAST( grammar, constsDetails( [
+                        "\"a\""
+                    ] ), {}, { reportFailures: false } );
+
+                } );
 
             } );
 
@@ -769,64 +879,130 @@ describe( "compiler pass |generateBytecode|", function () {
 
     describe( "for class", function () {
 
-        it( "generates correct bytecode", function () {
+        describe( "when |reportFailures=true|", function () {
 
-            expect( pass ).to.changeAST( "start = [a]", bytecodeDetails( [
-                23, 1,         // EXPECT <1>
-                20, 0, 2, 1,   // MATCH_REGEXP <0>
-                21, 1,         //   * ACCEPT_N
-                3              //   * PUSH_FAILED
-            ] ) );
+            it( "generates correct bytecode", function () {
 
-        } );
-
-        describe( "non-inverted case-sensitive", function () {
-
-            it( "defines correct constants", function () {
-
-                expect( pass ).to.changeAST( "start = [a]", constsDetails( [
-                    "/^[a]/",
-                    "peg$classExpectation([\"a\"], false, false)"
+                expect( pass ).to.changeAST( "start = [a]", bytecodeDetails( [
+                    23, 1,         // EXPECT <1>
+                    20, 0, 2, 1,   // MATCH_REGEXP <0>
+                    21, 1,         //   * ACCEPT_N
+                    3              //   * PUSH_FAILED
                 ] ) );
+
+            } );
+
+            describe( "non-inverted case-sensitive", function () {
+
+                it( "defines correct constants", function () {
+
+                    expect( pass ).to.changeAST( "start = [a]", constsDetails( [
+                        "/^[a]/",
+                        "peg$classExpectation([\"a\"], false, false)"
+                    ] ) );
+
+                } );
+
+            } );
+
+            describe( "inverted case-sensitive", function () {
+
+                it( "defines correct constants", function () {
+
+                    expect( pass ).to.changeAST( "start = [^a]", constsDetails( [
+                        "/^[^a]/",
+                        "peg$classExpectation([\"a\"], true, false)"
+                    ] ) );
+
+                } );
+
+            } );
+
+            describe( "non-inverted case-insensitive", function () {
+
+                it( "defines correct constants", function () {
+
+                    expect( pass ).to.changeAST( "start = [a]i", constsDetails( [
+                        "/^[a]/i",
+                        "peg$classExpectation([\"a\"], false, true)"
+                    ] ) );
+
+                } );
+
+            } );
+
+            describe( "complex", function () {
+
+                it( "defines correct constants", function () {
+
+                    expect( pass ).to.changeAST( "start = [ab-def-hij-l]", constsDetails( [
+                        "/^[ab-def-hij-l]/",
+                        "peg$classExpectation([\"a\", [\"b\", \"d\"], \"e\", [\"f\", \"h\"], \"i\", [\"j\", \"l\"]], false, false)"
+                    ] ) );
+
+                } );
 
             } );
 
         } );
 
-        describe( "inverted case-sensitive", function () {
+        describe( "when |reportFailures=false|", function () {
 
-            it( "defines correct constants", function () {
+            it( "generates correct bytecode", function () {
 
-                expect( pass ).to.changeAST( "start = [^a]", constsDetails( [
-                    "/^[^a]/",
-                    "peg$classExpectation([\"a\"], true, false)"
-                ] ) );
-
-            } );
-
-        } );
-
-        describe( "non-inverted case-insensitive", function () {
-
-            it( "defines correct constants", function () {
-
-                expect( pass ).to.changeAST( "start = [a]i", constsDetails( [
-                    "/^[a]/i",
-                    "peg$classExpectation([\"a\"], false, true)"
-                ] ) );
+                expect( pass ).to.changeAST( "start = [a]", bytecodeDetails( [
+                    20, 0, 2, 1,   // MATCH_REGEXP <0>
+                    21, 1,         //   * ACCEPT_N
+                    3              //   * PUSH_FAILED
+                ] ), {}, { reportFailures: false } );
 
             } );
 
-        } );
+            describe( "non-inverted case-sensitive", function () {
 
-        describe( "complex", function () {
+                it( "defines correct constants", function () {
 
-            it( "defines correct constants", function () {
+                    expect( pass ).to.changeAST( "start = [a]", constsDetails( [
+                        "/^[a]/"
+                    ] ), {}, { reportFailures: false } );
 
-                expect( pass ).to.changeAST( "start = [ab-def-hij-l]", constsDetails( [
-                    "/^[ab-def-hij-l]/",
-                    "peg$classExpectation([\"a\", [\"b\", \"d\"], \"e\", [\"f\", \"h\"], \"i\", [\"j\", \"l\"]], false, false)"
-                ] ) );
+                } );
+
+            } );
+
+            describe( "inverted case-sensitive", function () {
+
+                it( "defines correct constants", function () {
+
+                    expect( pass ).to.changeAST( "start = [^a]", constsDetails( [
+                        "/^[^a]/"
+                    ] ), {}, { reportFailures: false } );
+
+                } );
+
+            } );
+
+            describe( "non-inverted case-insensitive", function () {
+
+                it( "defines correct constants", function () {
+
+                    expect( pass ).to.changeAST( "start = [a]i", constsDetails( [
+                        "/^[a]/i"
+                    ] ), {}, { reportFailures: false } );
+
+                } );
+
+            } );
+
+            describe( "complex", function () {
+
+                it( "defines correct constants", function () {
+
+                    expect( pass ).to.changeAST( "start = [ab-def-hij-l]", constsDetails( [
+                        "/^[ab-def-hij-l]/"
+                    ] ), {}, { reportFailures: false } );
+
+                } );
 
             } );
 
@@ -836,25 +1012,56 @@ describe( "compiler pass |generateBytecode|", function () {
 
     describe( "for any", function () {
 
-        const grammar = "start = .";
+        describe( "when |reportFailures=true|", function () {
 
-        it( "generates bytecode", function () {
+            const grammar = "start = .";
 
-            expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                23, 0,      // EXPECT <0>
-                17, 2, 1,   // MATCH_ANY
-                21, 1,      //   * ACCEPT_N
-                3           //   * PUSH_FAILED
-            ] ) );
+            it( "generates bytecode", function () {
+
+                expect( pass ).to.changeAST( grammar, bytecodeDetails( [
+                    23, 0,      // EXPECT <0>
+                    17, 2, 1,   // MATCH_ANY
+                    21, 1,      //   * ACCEPT_N
+                    3           //   * PUSH_FAILED
+                ] ) );
+
+            } );
+
+            it( "defines correct constants", function () {
+
+                expect( pass ).to.changeAST(
+                    grammar,
+                    constsDetails( [ "peg$anyExpectation()" ] )
+                );
+
+            } );
 
         } );
 
-        it( "defines correct constants", function () {
+        describe( "when |reportFailures=false|", function () {
 
-            expect( pass ).to.changeAST(
-                grammar,
-                constsDetails( [ "peg$anyExpectation()" ] )
-            );
+            const grammar = "start = .";
+
+            it( "generates bytecode", function () {
+
+                expect( pass ).to.changeAST( grammar, bytecodeDetails( [
+                    17, 2, 1,   // MATCH_ANY
+                    21, 1,      //   * ACCEPT_N
+                    3           //   * PUSH_FAILED
+                ] ), {}, { reportFailures: false } );
+
+            } );
+
+            it( "defines correct constants", function () {
+
+                expect( pass ).to.changeAST(
+                    grammar,
+                    constsDetails( [] ),
+                    {},
+                    { reportFailures: false }
+                );
+
+            } );
 
         } );
 

--- a/test/spec/unit/compiler/passes/helpers.js
+++ b/test/spec/unit/compiler/passes/helpers.js
@@ -67,7 +67,7 @@ module.exports = function ( chai, utils ) {
 
         this.assert(
             matchProps( ast, props ),
-            "expected #{this} to change the AST to match #{exp}",
+            "expected #{this} to change the AST to match #{exp} but #{act} was produced",
             "expected #{this} to not change the AST to match #{exp}",
             props,
             ast

--- a/test/spec/unit/compiler/passes/helpers.js
+++ b/test/spec/unit/compiler/passes/helpers.js
@@ -6,9 +6,10 @@ module.exports = function ( chai, utils ) {
 
     const Assertion = chai.Assertion;
 
-    Assertion.addMethod( "changeAST", function ( grammar, props, options ) {
+    Assertion.addMethod( "changeAST", function ( grammar, props, options, additionalRuleProps ) {
 
         options = typeof options !== "undefined" ? options : {};
+        additionalRuleProps = typeof additionalRuleProps !== "undefined" ? additionalRuleProps : { reportFailures: true };
 
         function matchProps( value, props ) {
 
@@ -62,6 +63,8 @@ module.exports = function ( chai, utils ) {
                 : [];
 
         }
+
+        ast.rules = ast.rules.map( rule => Object.assign( rule, additionalRuleProps ) );
 
         utils.flag( this, "object" )( ast, options );
 


### PR DESCRIPTION
The first сommit removed unnecessary checks with `peg$silentFails` if earlier in the parse function for the rule this variable was incremented. The second commit extends optimization for boundaries of rules: if rule always used in context of suppressed failure generation (there three of such context -- rules under `named`, `simple_and` and `simple_not` AST nodes) checks aren't generated.

The size of the generated parsers slightly decreased, and speed, most likely, didn't change though it would be worth expecting small improving. Measurements yield contradictory results, here the most noticeable of them with deviations in both sides (from 7 carried-out tests, in remaining distinction sticks near +/-0.5%, master is 48f5ea4b37157040edba01e098a81c7bb78cbebe):

``` bash
$ ./impact master optimize-silent-fails
Measuring commit master... OK
Measuring commit optimize-silent-fails... OK

Speed impact
------------
Before:     164.95 kB/s
After:      141.32 kB/s
Difference: -14.33%

Size impact
-----------
Before:     721705 b
After:      646518 b
Difference: -10.42%

(Measured by /tools/impact with Node.js v0.10.18 on MINGW32_NT-6.0 1.0.18(0.48/3/2) i686.)
```

``` bash
$ ./impact master optimize-silent-fails
Measuring commit master... OK
Measuring commit optimize-silent-fails... OK

Speed impact
------------
Before:     152.07 kB/s
After:      173.18 kB/s
Difference: 13.88%

Size impact
-----------
Before:     721705 b
After:      646518 b
Difference: -10.42%

(Measured by /tools/impact with Node.js v0.10.18 on MINGW32_NT-6.0 1.0.18(0.48/3/2) i686.)
```
