### PR TITLE
Issue #402: Add new option |newLocation| when parse input to hook loc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ object to the `parse` method. The following options are supported:
 
   * `startRule` — name of the rule to start parsing from
   * `tracer` — tracer to use
+  * `newLocation` — hook function for tweak location information, attached to all
+    AST nodes of grammar and returned by the API function `location`. It accept one
+    argument — computed location (format described in description of the `location` function).
+    For example you can use this function to attach filename to all errors, generated
+    by the parser
 
 Parsers can also support their own custom options.
 
@@ -333,7 +338,9 @@ The code inside the predicate can also access location information using the
 
 The `start` and `end` properties both refer to the current parse position. The
 `offset` property contains an offset as a zero-based index and `line` and
-`column` properties contain a line and a column as one-based indices.
+`column` properties contain a line and a column as one-based indices. Note, that
+you can tweak returned information by the `newLocation` function in `options`. See
+description of allowed options for `parse` function for details.
 
 The code inside the predicate can also access the parser object using the
 `parser` variable and options passed to the parser using the `options` variable.
@@ -362,7 +369,9 @@ The code inside the predicate can also access location information using the
 
 The `start` and `end` properties both refer to the current parse position. The
 `offset` property contains an offset as a zero-based index and `line` and
-`column` properties contain a line and a column as one-based indices.
+`column` properties contain a line and a column as one-based indices. Note, that
+you can tweak returned information by the `newLocation` function in `options`. See
+description of allowed options for `parse` function for details.
 
 The code inside the predicate can also access the parser object using the
 `parser` variable and options passed to the parser using the `options` variable.
@@ -425,7 +434,9 @@ The code inside the action can also access location information using the
 The `start` property refers to the position at the beginning of the expression,
 the `end` property refers to position after the end of the expression. The
 `offset` property contains an offset as a zero-based index and `line` and
-`column` properties contain a line and a column as one-based indices.
+`column` properties contain a line and a column as one-based indices. Note, that
+you can tweak returned information by the `newLocation` function in `options`. See
+description of allowed options for `parse` function for details.
 
 The code inside the action can also access the parser object using the `parser`
 variable and options passed to the parser using the `options` variable.

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -899,6 +899,7 @@ function generateJS(ast, options) {
     '        peg$maxFailPos       = 0,',
     '        peg$maxFailExpected  = [],',
     '        peg$silentFails      = 0,',   // 0 = report failures, > 0 = silence failures
+    '        peg$newLocation      = function(loc) { return loc; },',
     ''
   ].join('\n'));
 
@@ -958,6 +959,13 @@ function generateJS(ast, options) {
   }
 
   parts.push([
+    '    if ("newLocation" in options) {',
+    '      if (typeof options.newLocation !== "function") {',
+    '        throw new Error("Option \\"newLocation\\" must be function, but its type is \\"" + (typeof options.newLocation) + "\\".");',
+    '      }',
+    '',
+    '      peg$newLocation = options.newLocation;',
+    '    }',
     '',
     '    function text() {',
     '      return input.substring(peg$savedPos, peg$currPos);',
@@ -971,7 +979,7 @@ function generateJS(ast, options) {
     '      throw peg$buildException(',
     '        null,',
     '        [{ type: "other", description: description }],',
-    '        peg$computeLocation(peg$savedPos, peg$currPos)',
+    '        location()',
     '      );',
     '    }',
     '',
@@ -979,7 +987,7 @@ function generateJS(ast, options) {
     '      throw peg$buildException(',
     '        message,',
     '        null,',
-    '        peg$computeLocation(peg$savedPos, peg$currPos)',
+    '        location()',
     '      );',
     '    }',
     '',
@@ -1029,7 +1037,7 @@ function generateJS(ast, options) {
     '      var startPosDetails = peg$computePosDetails(startPos),',
     '          endPosDetails   = peg$computePosDetails(endPos);',
     '',
-    '      return {',
+    '      return peg$newLocation({',
     '        start: {',
     '          offset: startPos,',
     '          line:   startPosDetails.line,',
@@ -1040,7 +1048,7 @@ function generateJS(ast, options) {
     '          line:   endPosDetails.line,',
     '          column: endPosDetails.column',
     '        }',
-    '      };',
+    '      });',
     '    }',
     '',
     '    function peg$fail(expected) {',

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -384,6 +384,7 @@ module.exports = (function() {
         peg$maxFailPos       = 0,
         peg$maxFailExpected  = [],
         peg$silentFails      = 0,
+        peg$newLocation      = function(loc) { return loc; },
 
         peg$result;
 
@@ -393,6 +394,13 @@ module.exports = (function() {
       }
 
       peg$startRuleFunction = peg$startRuleFunctions[options.startRule];
+    }
+    if ("newLocation" in options) {
+      if (typeof options.newLocation !== "function") {
+        throw new Error("Option \"newLocation\" must be function, but its type is \"" + (typeof options.newLocation) + "\".");
+      }
+
+      peg$newLocation = options.newLocation;
     }
 
     function text() {
@@ -407,7 +415,7 @@ module.exports = (function() {
       throw peg$buildException(
         null,
         [{ type: "other", description: description }],
-        peg$computeLocation(peg$savedPos, peg$currPos)
+        location()
       );
     }
 
@@ -415,7 +423,7 @@ module.exports = (function() {
       throw peg$buildException(
         message,
         null,
-        peg$computeLocation(peg$savedPos, peg$currPos)
+        location()
       );
     }
 
@@ -465,7 +473,7 @@ module.exports = (function() {
       var startPosDetails = peg$computePosDetails(startPos),
           endPosDetails   = peg$computePosDetails(endPos);
 
-      return {
+      return peg$newLocation({
         start: {
           offset: startPos,
           line:   startPosDetails.line,
@@ -476,7 +484,7 @@ module.exports = (function() {
           line:   endPosDetails.line,
           column: endPosDetails.column
         }
-      };
+      });
     }
 
     function peg$fail(expected) {

--- a/spec/behavior/generated-parser-behavior.spec.js
+++ b/spec/behavior/generated-parser-behavior.spec.js
@@ -1450,6 +1450,48 @@ describe("generated parser behavior", function() {
           });
         });
 
+        it("use |options.newLocation| for change location", function() {
+          var parser = PEG.buildParser('start = "a"', options);
+
+          expect(parser).toFailToParse(
+            "a",
+            { newLocation: 42 },
+            { message: 'Option "newLocation" must be function, but its type is "number".' }
+          );
+          expect(parser).toFailToParse(
+            "b",
+            { newLocation: 42 },
+            { message: 'Option "newLocation" must be function, but its type is "number".' }
+          );
+
+          expect(parser).toFailToParse(
+            "b",
+            { newLocation: function() { return 42; } },
+            { location: 42 }
+          );
+
+          parser = PEG.buildParser('start "start" = "a"', options);
+          expect(parser).toFailToParse(
+            "b",
+            { newLocation: function() { return 42; } },
+            { location: 42 }
+          );
+
+          parser = PEG.buildParser('start = . { expected("a"); }', options);
+          expect(parser).toFailToParse(
+            "b",
+            { newLocation: function() { return 42; } },
+            { location: 42 }
+          );
+
+          parser = PEG.buildParser('start = . { error("a"); }', options);
+          expect(parser).toFailToParse(
+            "b",
+            { newLocation: function() { return 42; } },
+            { location: 42 }
+          );
+        });
+
         it("reports position correctly in complex cases", function() {
           var parser = PEG.buildParser([
                 'start  = line (nl+ line)*',


### PR DESCRIPTION
…ation information, collected by |location()| API function.

For example, to add filename information to all locations use this code:
```js
var parser = ...;
var filename = ...;
var grammar = fs.readFileSync(filename, 'utf-8');
parser.parse(grammar, { newLocation: function(loc) { loc.fileName = fileName; return loc; } });
```

Closes #402.