### PR TITLE
Fixed npm & bower badges to show PEGjs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-[![Build status](https://img.shields.io/travis/pegjs/pegjs.svg)](https://travis-ci.org/pegjs/pegjs)
-[![npm version](https://img.shields.io/npm/v/npm.svg)](https://www.npmjs.com/package/pegjs)
-[![Bower version](https://img.shields.io/bower/v/bootstrap.svg)](https://github.com/pegjs/bower)
+
+[![Build status](https://img.shields.io/travis/pegjs/pegjs.svg)](https://travis-ci.org/pegjs/pegjs) 
+[![npm version](https://img.shields.io/npm/v/pegjs.svg)](https://www.npmjs.com/package/pegjs) 
+[![Bower version](https://img.shields.io/bower/v/pegjs.svg)](https://github.com/pegjs/bower) 
 [![License](https://img.shields.io/badge/license-mit-blue.svg)](https://opensource.org/licenses/MIT)
 
 PEG.js


### PR DESCRIPTION
I've fixed the badge urls to show the current version of pegjs rather than the current version of npm and bower.
I just worked this out for my own PEGjs project :)  The npm example on shield.io shows the version of npm itself, which makes it hard to work out what to change to point it at your own project.