### PR TITLE
Added 'kind' to VariableDeclaration in example

### DIFF
--- a/examples/javascript.pegjs
+++ b/examples/javascript.pegjs
@@ -1016,7 +1016,8 @@ VariableStatement
   = VarToken __ declarations:VariableDeclarationList EOS {
       return {
         type:         "VariableDeclaration",
-        declarations: declarations
+        declarations: declarations,
+        kind:         "var"
       };
     }
 
@@ -1124,7 +1125,8 @@ IterationStatement
         type:   "ForStatement",
         init:   {
           type:         "VariableDeclaration",
-          declarations: declarations
+          declarations: declarations,
+          kind:         "var"
         },
         test:   extractOptional(test, 0),
         update: extractOptional(update, 0),
@@ -1158,7 +1160,8 @@ IterationStatement
         type:  "ForInStatement",
         left:  {
           type:         "VariableDeclaration",
-          declarations: declarations
+          declarations: declarations,
+          kind:         "var"
         },
         right: right,
         body:  body


### PR DESCRIPTION
The JavaScript example grammar's VariableDeclaration was missing the 'kind'
member (always set to "var"). Resulting AST tested with [escodegen][].

### Test code

```js
var i = 0;
```

### AST

```json
{
   "type": "Program",
   "body": [
      {
         "type": "VariableDeclaration",
         "declarations": [
            {
               "type": "VariableDeclarator",
               "id": {
                  "type": "Identifier",
                  "name": "i"
               },
               "init": {
                  "type": "Literal",
                  "value": 0
               }
            }
         ],
         "kind": "var"
      }
   ]
}
```

See [estree's spec.md][estree] for the version of the spec used. 

[estree]: https://github.com/estree/estree/blob/bc34a7cc861640aa8ee18d93186720be1b13db53/spec.md#variabledeclaration
[escodegen]: https://github.com/estools/escodegen