### PR TITLE
Build LogicalExpression instead of BinaryExpression nodes as per ES5 spec

### DIFF
--- a/examples/javascript.pegjs
+++ b/examples/javascript.pegjs
@@ -855,12 +855,12 @@ BitwiseOROperator
 LogicalANDExpression
   = head:BitwiseORExpression
     tail:(__ LogicalANDOperator __ BitwiseORExpression)*
-    { return buildBinaryExpression(head, tail); }
+    { return buildLogicalExpression(head, tail); }
 
 LogicalANDExpressionNoIn
   = head:BitwiseORExpressionNoIn
     tail:(__ LogicalANDOperator __ BitwiseORExpressionNoIn)*
-    { return buildBinaryExpression(head, tail); }
+    { return buildLogicalExpression(head, tail); }
 
 LogicalANDOperator
   = "&&"
@@ -868,12 +868,12 @@ LogicalANDOperator
 LogicalORExpression
   = head:LogicalANDExpression
     tail:(__ LogicalOROperator __ LogicalANDExpression)*
-    { return buildBinaryExpression(head, tail); }
+    { return buildLogicalExpression(head, tail); }
 
 LogicalORExpressionNoIn
   = head:LogicalANDExpressionNoIn
     tail:(__ LogicalOROperator __ LogicalANDExpressionNoIn)*
-    { return buildBinaryExpression(head, tail); }
+    { return buildLogicalExpression(head, tail); }
 
 LogicalOROperator
   = "||"


### PR DESCRIPTION
The `buildLogicalExpression` function was defined but not used; specifically,
the `Logical(AND|OR)Expression(NoIn)?` rules were constructing `BinaryExpression`
nodes, but are now `LogicalExpression` nodes as per the [ESTree spec][1].

[1]: https://github.com/estree/estree/blob/2661f6647e875cac17a73f70f5e358507a900827/es5.md#logicalexpression