### PR TITLE
Add support for ES modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ You can tweak the generated parser with several options:
     `peg.generate`
   * `--extra-options-file` — file with additional options (in JSON format) to
     pass to `peg.generate`
-  * `--format` — format of the generated parser: `amd`, `commonjs`, `globals`,
-    `umd` (default: `commonjs`)
+  * `--format` — format of the generated parser: `amd`, `commonjs`, `es`,
+    `globals`, `umd` (default: `commonjs`)
   * `--optimize` — selects between optimizing the generated parser for parsing
     speed (`speed`) or code size (`size`) (default: `speed`)
   * `--plugin` — makes PEG.js use a specified plugin (can be specified multiple
@@ -142,14 +142,14 @@ object to `peg.generate`. The following options are supported:
     `false`)
   * `dependencies` — parser dependencies, the value is an object which maps
     variables used to access the dependencies in the parser to module IDs used
-    to load them; valid only when `format` is set to `"amd"`, `"commonjs"`, or
-    `"umd"` (default: `{}`)
+    to load them; valid only when `format` is set to `"amd"`, `"commonjs"`,
+    `"es"`, or `"umd"` (default: `{}`)
   * `exportVar` — name of a global variable into which the parser object is
     assigned to when no module loader is detected; valid only when `format` is
     set to `"globals"` or `"umd"` (default: `null`)
   * `format` — format of the generated parser (`"amd"`, `"bare"`, `"commonjs"`,
-    `"globals"`, or `"umd"`); valid only when `output` is set to `"source"`
-    (default: `"bare"`)
+    `"es"`, `"globals"`, or `"umd"`); valid only when `output` is set to
+    `"source"` (default: `"bare"`)
   * `optimize`— selects between optimizing the generated parser for parsing
     speed (`"speed"`) or code size (`"size"`) (default: `"speed"`)
   * `output` — if set to `"parser"`, the method will return generated parser

--- a/bin/pegjs
+++ b/bin/pegjs
@@ -30,8 +30,8 @@ function printHelp() {
   console.log("                                     to peg.generate");
   console.log("      --extra-options-file <file>    file with additional options (in JSON");
   console.log("                                     format) to pass to peg.generate");
-  console.log("      --format <format>              format of the generated parser: amd,");
-  console.log("                                     commonjs, globals, umd (default: commonjs)");
+  console.log("      --format <format>              format of the generated parser: amd, commonjs");
+  console.log("                                     es, globals, umd (default: commonjs)");
   console.log("  -h, --help                         print help and exit");
   console.log("  -O, --optimize <goal>              select optimization for speed or size");
   console.log("                                     (default: speed)");

--- a/bin/pegjs
+++ b/bin/pegjs
@@ -116,6 +116,9 @@ let options = {
   trace: false
 };
 
+const MODULE_FORMATS = ["amd", "commonjs", "es", "globals", "umd"];
+const MODULE_FORMATS_WITH_DEPS = ["amd", "commonjs", "es", "umd"];
+
 while (args.length > 0 && isOption(args[0])) {
   let json, id, mod;
 
@@ -183,8 +186,8 @@ while (args.length > 0 && isOption(args[0])) {
       if (args.length === 0) {
         abort("Missing parameter of the --format option.");
       }
-      if (args[0] !== "amd" && args[0] !== "commonjs" && args[0] !== "es" && args[0] !== "globals" && args[0] !== "umd") {
-        abort("Module format must be one of \"amd\", \"commonjs\", \"es\", \"globals\", and \"umd\".");
+      if (MODULE_FORMATS.indexOf(args[0]) === -1) {
+        abort("Module format must be one of " + MODULE_FORMATS.map(format => `"${format}"`).join(", ") + ".");
       }
       options.format = args[0];
       break;
@@ -253,7 +256,7 @@ while (args.length > 0 && isOption(args[0])) {
 }
 
 if (Object.keys(options.dependencies).length > 0) {
-  if (options.format !== "amd" && options.format !== "commonjs" && options.format !== "es" && options.format !== "umd") {
+  if (MODULE_FORMATS_WITH_DEPS.indexOf(options.format) === -1) {
     abort("Can't use the -d/--dependency option with the \"" + options.format + "\" module format.");
   }
 }

--- a/bin/pegjs
+++ b/bin/pegjs
@@ -183,8 +183,8 @@ while (args.length > 0 && isOption(args[0])) {
       if (args.length === 0) {
         abort("Missing parameter of the --format option.");
       }
-      if (args[0] !== "amd" && args[0] !== "commonjs" && args[0] !== "esm" && args[0] !== "globals" && args[0] !== "umd") {
-        abort("Module format must be one of \"amd\", \"commonjs\", \"esm\", \"globals\", and \"umd\".");
+      if (args[0] !== "amd" && args[0] !== "commonjs" && args[0] !== "es" && args[0] !== "globals" && args[0] !== "umd") {
+        abort("Module format must be one of \"amd\", \"commonjs\", \"es\", \"globals\", and \"umd\".");
       }
       options.format = args[0];
       break;
@@ -253,7 +253,7 @@ while (args.length > 0 && isOption(args[0])) {
 }
 
 if (Object.keys(options.dependencies).length > 0) {
-  if (options.format !== "amd" && options.format !== "commonjs" && options.format !== "esm" && options.format !== "umd") {
+  if (options.format !== "amd" && options.format !== "commonjs" && options.format !== "es" && options.format !== "umd") {
     abort("Can't use the -d/--dependency option with the \"" + options.format + "\" module format.");
   }
 }

--- a/bin/pegjs
+++ b/bin/pegjs
@@ -183,8 +183,8 @@ while (args.length > 0 && isOption(args[0])) {
       if (args.length === 0) {
         abort("Missing parameter of the --format option.");
       }
-      if (args[0] !== "amd" && args[0] !== "commonjs" && args[0] !== "globals" && args[0] !== "umd") {
-        abort("Module format must be one of \"amd\", \"commonjs\", \"globals\", and \"umd\".");
+      if (args[0] !== "amd" && args[0] !== "commonjs" && args[0] !== "esm" && args[0] !== "globals" && args[0] !== "umd") {
+        abort("Module format must be one of \"amd\", \"commonjs\", \"esm\", \"globals\", and \"umd\".");
       }
       options.format = args[0];
       break;
@@ -253,7 +253,7 @@ while (args.length > 0 && isOption(args[0])) {
 }
 
 if (Object.keys(options.dependencies).length > 0) {
-  if (options.format !== "amd" && options.format !== "commonjs" && options.format !== "umd") {
+  if (options.format !== "amd" && options.format !== "commonjs" && options.format !== "esm" && options.format !== "umd") {
     abort("Can't use the -d/--dependency option with the \"" + options.format + "\" module format.");
   }
 }

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -1290,7 +1290,7 @@ function generateJS(ast, options) {
         return parts.join("\n");
       },
 
-      esm() {
+      es() {
         let parts = [];
         let dependencyVars = Object.keys(options.dependencies);
 

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -1227,6 +1227,23 @@ function generateJS(ast, options) {
         ].join("\n");
     }
 
+    function generateParserExports() {
+      return options.trace
+        ? [
+          "{",
+          "  peg$SyntaxError as SyntaxError,",
+          "  peg$DefaultTracer as DefaultTracer,",
+          "  peg$parse as parse",
+          "}"
+        ].join("\n")
+        : [
+          "{",
+          "  peg$SyntaxError as SyntaxError,",
+          "  peg$parse as parse",
+          "}"
+        ].join("\n");
+    }
+
     let generators = {
       bare() {
         return [
@@ -1269,6 +1286,36 @@ function generateJS(ast, options) {
           "module.exports = " + generateParserObject() + ";",
           ""
         ].join("\n"));
+
+        return parts.join("\n");
+      },
+
+      esm() {
+        let parts = [];
+        let dependencyVars = Object.keys(options.dependencies);
+
+        parts.push(
+          generateGeneratedByComment(),
+          ""
+        );
+
+        if (dependencyVars.length > 0) {
+          dependencyVars.forEach(variable => {
+            parts.push("import " + variable
+              + " from \""
+              + js.stringEscape(options.dependencies[variable])
+              + "\";"
+            );
+          });
+          parts.push("");
+        }
+
+        parts.push(
+          toplevelCode,
+          "",
+          "export " + generateParserExports() + ";",
+          ""
+        );
 
         return parts.join("\n");
       },


### PR DESCRIPTION
Related to #423.

A couple of notes:
- I noticed that the only place where the options are being validated is in the `bin/pegjs` script, shouldn't it be in the `generate` method instead?
- I couldn't find any existing tests for different output formats, are there any?

This does not yet contain changes to README, which I will add later if the code is good first.