### PR TITLE
Update package.json bin reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "CHANGELOG.md",
     "LICENSE",
     "README.md",
-    "bin/pegjs",
+    "bin/peg.js",
+    "bin/options.js",
+    "bin/usage.txt",
     "examples/arithmetics.pegjs",
     "examples/css.pegjs",
     "examples/javascript.pegjs",
@@ -41,7 +43,9 @@
     "package.json"
   ],
   "main": "lib/peg",
-  "bin": "bin/peg",
+  "bin": {
+    "peg": "bin/peg.js"
+  },
   "repository": "pegjs/pegjs",
   "scripts": {
     "lint": "gulp lint",


### PR DESCRIPTION
The bin field should reference the actual file. If it should be
installed as "peg" then it needs to mentioned as the "peg" key in a
"bin" mapping.
    
Additionally, the bin files need to be included in the list of published
files.