### PR TITLE
Replace custom `clone(...)` function with `Object.assign({}, ...)`

### DIFF
--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -202,16 +202,6 @@ function generateBytecode(ast) {
     );
   }
 
-  function cloneEnv(env) {
-    let clone = {};
-
-    Object.keys(env).forEach(name => {
-      clone[name] = env[name];
-    });
-
-    return clone;
-  }
-
   function buildSequence() {
     return Array.prototype.concat.apply([], arguments);
   }
@@ -240,7 +230,7 @@ function generateBytecode(ast) {
       [op.SILENT_FAILS_ON],
       generate(expression, {
         sp: context.sp + 1,
-        env: cloneEnv(context.env),
+        env: Object.assign({}, context.env),
         action: null
       }),
       [op.SILENT_FAILS_OFF],
@@ -324,7 +314,7 @@ function generateBytecode(ast) {
         return buildSequence(
           generate(alternatives[0], {
             sp: context.sp,
-            env: cloneEnv(context.env),
+            env: Object.assign({}, context.env),
             action: null
           }),
           alternatives.length > 1
@@ -344,7 +334,7 @@ function generateBytecode(ast) {
     },
 
     action(node, context) {
-      let env = cloneEnv(context.env);
+      let env = Object.assign({}, context.env);
       let emitCall = node.expression.type !== "sequence"
                   || node.expression.elements.length === 0;
       let expressionCode = generate(node.expression, {
@@ -429,7 +419,7 @@ function generateBytecode(ast) {
     },
 
     labeled(node, context) {
-      let env = cloneEnv(context.env);
+      let env = Object.assign({}, context.env);
 
       context.env[node.label] = context.sp + 1;
 
@@ -445,7 +435,7 @@ function generateBytecode(ast) {
         [op.PUSH_CURR_POS],
         generate(node.expression, {
           sp: context.sp + 1,
-          env: cloneEnv(context.env),
+          env: Object.assign({}, context.env),
           action: null
         }),
         buildCondition(
@@ -468,7 +458,7 @@ function generateBytecode(ast) {
       return buildSequence(
         generate(node.expression, {
           sp: context.sp,
-          env: cloneEnv(context.env),
+          env: Object.assign({}, context.env),
           action: null
         }),
         buildCondition(
@@ -482,7 +472,7 @@ function generateBytecode(ast) {
     zero_or_more(node, context) {
       let expressionCode = generate(node.expression, {
         sp: context.sp + 1,
-        env: cloneEnv(context.env),
+        env: Object.assign({}, context.env),
         action: null
       });
 
@@ -497,7 +487,7 @@ function generateBytecode(ast) {
     one_or_more(node, context) {
       let expressionCode = generate(node.expression, {
         sp: context.sp + 1,
-        env: cloneEnv(context.env),
+        env: Object.assign({}, context.env),
         action: null
       });
 
@@ -515,7 +505,7 @@ function generateBytecode(ast) {
     group(node, context) {
       return generate(node.expression, {
         sp: context.sp,
-        env: cloneEnv(context.env),
+        env: Object.assign({}, context.env),
         action: null
       });
     },

--- a/lib/compiler/passes/report-duplicate-labels.js
+++ b/lib/compiler/passes/report-duplicate-labels.js
@@ -5,18 +5,8 @@ let visitor = require("../visitor");
 
 // Checks that each label is defined only once within each scope.
 function reportDuplicateLabels(ast) {
-  function cloneEnv(env) {
-    let clone = {};
-
-    Object.keys(env).forEach(name => {
-      clone[name] = env[name];
-    });
-
-    return clone;
-  }
-
   function checkExpressionWithClonedEnv(node, env) {
-    check(node.expression, cloneEnv(env));
+    check(node.expression, Object.assign({}, env));
   }
 
   let check = visitor.build({
@@ -26,7 +16,7 @@ function reportDuplicateLabels(ast) {
 
     choice(node, env) {
       node.alternatives.forEach(alternative => {
-        check(alternative, cloneEnv(env));
+        check(alternative, Object.assign({}, env));
       });
     },
 

--- a/test/behavior/generated-parser-behavior.spec.js
+++ b/test/behavior/generated-parser-behavior.spec.js
@@ -10,16 +10,6 @@ let expect = chai.expect;
 
 describe("generated parser behavior", function() {
   function varyOptimizationOptions(block) {
-    function clone(object) {
-      let result = {};
-
-      Object.keys(object).forEach(key => {
-        result[key] = object[key];
-      });
-
-      return result;
-    }
-
     let optionsVariants = [
       { cache: false, optimize: "speed", trace: false },
       { cache: false, optimize: "speed", trace: true  },
@@ -34,7 +24,7 @@ describe("generated parser behavior", function() {
     optionsVariants.forEach(variant => {
       describe(
         "with options " + chai.util.inspect(variant),
-        function() { block(clone(variant)); }
+        function() { block(Object.assign({}, variant)); }
       );
     });
   }


### PR DESCRIPTION
More standard way to clone objects