### PR TITLE
Partial fix #194 - nonsenses error messages with semantic predicates

### DIFF
--- a/lib/compiler/opcodes.js
+++ b/lib/compiler/opcodes.js
@@ -49,7 +49,10 @@ const opcodes = {
     // Failure Reporting
 
     SILENT_FAILS_ON:  28,   // SILENT_FAILS_ON
-    SILENT_FAILS_OFF: 29    // SILENT_FAILS_OFF
+    SILENT_FAILS_OFF: 29,   // SILENT_FAILS_OFF
+
+    EXPECT_NS_BEGIN:  38,   // EXPECT_NS_BEGIN
+    EXPECT_NS_END:    39    // EXPECT_NS_END
 
 };
 

--- a/lib/compiler/opcodes.js
+++ b/lib/compiler/opcodes.js
@@ -34,7 +34,7 @@ const opcodes = {
     MATCH_REGEXP:     20,   // MATCH_REGEXP r, a, f, ...
     ACCEPT_N:         21,   // ACCEPT_N n
     ACCEPT_STRING:    22,   // ACCEPT_STRING s
-    FAIL:             23,   // FAIL e
+    EXPECT:           23,   // EXPECT e
 
     // Calls
 

--- a/lib/compiler/opcodes.js
+++ b/lib/compiler/opcodes.js
@@ -52,7 +52,7 @@ const opcodes = {
     SILENT_FAILS_OFF: 29,   // SILENT_FAILS_OFF
 
     EXPECT_NS_BEGIN:  38,   // EXPECT_NS_BEGIN
-    EXPECT_NS_END:    39    // EXPECT_NS_END
+    EXPECT_NS_END:    39    // EXPECT_NS_END invert
 
 };
 

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -328,12 +328,7 @@ function generateBytecode( ast ) {
                 [ op.EXPECT, nameIndex ],
                 [ op.SILENT_FAILS_ON ],
                 generate( node.expression, context ),
-                [ op.SILENT_FAILS_OFF ],
-                buildCondition(
-                    [ op.IF_ERROR ],
-                    [ op.PUSH_FAILED ],
-                    []
-                )
+                [ op.SILENT_FAILS_OFF ]
             );
 
         },

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -325,12 +325,13 @@ function generateBytecode( ast ) {
             );
 
             return buildSequence(
+                [ op.EXPECT, nameIndex ],
                 [ op.SILENT_FAILS_ON ],
                 generate( node.expression, context ),
                 [ op.SILENT_FAILS_OFF ],
                 buildCondition(
                     [ op.IF_ERROR ],
-                    buildSequence( [ op.PUSH_FAILED ], [ op.EXPECT, nameIndex ] ),
+                    [ op.PUSH_FAILED ],
                     []
                 )
             );
@@ -599,14 +600,17 @@ function generateBytecode( ast ) {
                 // For case-sensitive strings the value must match the beginning of the
                 // remaining input exactly. As a result, we can use |ACCEPT_STRING| and
                 // save one |substr| call that would be needed if we used |ACCEPT_N|.
-                return buildCondition(
-                    node.ignoreCase
-                        ? [ op.MATCH_STRING_IC, stringIndex ]
-                        : [ op.MATCH_STRING, stringIndex ],
-                    node.ignoreCase
-                        ? [ op.ACCEPT_N, node.value.length ]
-                        : [ op.ACCEPT_STRING, stringIndex ],
-                    buildSequence( [ op.PUSH_FAILED ], [ op.EXPECT, expectedIndex ] )
+                return buildSequence(
+                    [ op.EXPECT, expectedIndex ],
+                    buildCondition(
+                        node.ignoreCase
+                            ? [ op.MATCH_STRING_IC, stringIndex ]
+                            : [ op.MATCH_STRING, stringIndex ],
+                        node.ignoreCase
+                            ? [ op.ACCEPT_N, node.value.length ]
+                            : [ op.ACCEPT_STRING, stringIndex ],
+                        [ op.PUSH_FAILED ]
+                    )
                 );
 
             }
@@ -651,10 +655,13 @@ function generateBytecode( ast ) {
                 + ")"
             );
 
-            return buildCondition(
-                [ op.MATCH_REGEXP, regexpIndex ],
-                [ op.ACCEPT_N, 1 ],
-                buildSequence( [ op.PUSH_FAILED ], [ op.EXPECT, expectedIndex ] )
+            return buildSequence(
+                [ op.EXPECT, expectedIndex ],
+                buildCondition(
+                    [ op.MATCH_REGEXP, regexpIndex ],
+                    [ op.ACCEPT_N, 1 ],
+                    [ op.PUSH_FAILED ]
+                )
             );
 
         },
@@ -663,10 +670,13 @@ function generateBytecode( ast ) {
 
             const expectedIndex = addConst( "peg$anyExpectation()" );
 
-            return buildCondition(
-                [ op.MATCH_ANY ],
-                [ op.ACCEPT_N, 1 ],
-                buildSequence( [ op.PUSH_FAILED ], [ op.EXPECT, expectedIndex ] )
+            return buildSequence(
+                [ op.EXPECT, expectedIndex ],
+                buildCondition(
+                    [ op.MATCH_ANY ],
+                    [ op.ACCEPT_N, 1 ],
+                    [ op.PUSH_FAILED ]
+                )
             );
 
         }

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -186,6 +186,14 @@ const visitor = require( "../visitor" );
 // [29] SILENT_FAILS_OFF
 //
 //        silentFails--;
+//
+// [38] EXPECT_NS_BEGIN
+//
+//        expected.push({ pos: curPos, variants: [] });
+//
+// [39] EXPECT_NS_END
+//
+//        expected.pop();
 function generateBytecode( ast ) {
 
     const consts = [];
@@ -251,13 +259,13 @@ function generateBytecode( ast ) {
 
         return buildSequence(
             [ op.PUSH_CURR_POS ],
-            [ op.SILENT_FAILS_ON ],
+            [ op.EXPECT_NS_BEGIN ],
             generate( expression, {
                 sp: context.sp + 1,
                 env: cloneEnv( context.env ),
                 action: null
             } ),
-            [ op.SILENT_FAILS_OFF ],
+            [ op.EXPECT_NS_END ],
             buildCondition(
                 [ negative ? op.IF_ERROR : op.IF_NOT_ERROR ],
                 buildSequence(

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -148,10 +148,9 @@ const visitor = require( "../visitor" );
 //        stack.push(consts[s]);
 //        currPos += consts[s].length;
 //
-// [23] FAIL e
+// [23] EXPECT e
 //
-//        stack.push(FAILED);
-//        fail(consts[e]);
+//        expect(consts[e]);
 //
 // Calls
 // -----
@@ -325,15 +324,15 @@ function generateBytecode( ast ) {
                 `peg$otherExpectation("${ js.stringEscape( node.name ) }")`
             );
 
-            // The code generated below is slightly suboptimal because |FAIL| pushes
-            // to the stack, so we need to stick a |POP| in front of it. We lack a
-            // dedicated instruction that would just report the failure and not touch
-            // the stack.
             return buildSequence(
                 [ op.SILENT_FAILS_ON ],
                 generate( node.expression, context ),
                 [ op.SILENT_FAILS_OFF ],
-                buildCondition( [ op.IF_ERROR ], [ op.FAIL, nameIndex ], [] )
+                buildCondition(
+                    [ op.IF_ERROR ],
+                    buildSequence( [ op.PUSH_FAILED ], [ op.EXPECT, nameIndex ] ),
+                    []
+                )
             );
 
         },
@@ -607,7 +606,7 @@ function generateBytecode( ast ) {
                     node.ignoreCase
                         ? [ op.ACCEPT_N, node.value.length ]
                         : [ op.ACCEPT_STRING, stringIndex ],
-                    [ op.FAIL, expectedIndex ]
+                    buildSequence( [ op.PUSH_FAILED ], [ op.EXPECT, expectedIndex ] )
                 );
 
             }
@@ -655,7 +654,7 @@ function generateBytecode( ast ) {
             return buildCondition(
                 [ op.MATCH_REGEXP, regexpIndex ],
                 [ op.ACCEPT_N, 1 ],
-                [ op.FAIL, expectedIndex ]
+                buildSequence( [ op.PUSH_FAILED ], [ op.EXPECT, expectedIndex ] )
             );
 
         },
@@ -667,7 +666,7 @@ function generateBytecode( ast ) {
             return buildCondition(
                 [ op.MATCH_ANY ],
                 [ op.ACCEPT_N, 1 ],
-                [ op.FAIL, expectedIndex ]
+                buildSequence( [ op.PUSH_FAILED ], [ op.EXPECT, expectedIndex ] )
             );
 
         }

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -191,9 +191,15 @@ const visitor = require( "../visitor" );
 //
 //        expected.push({ pos: curPos, variants: [] });
 //
-// [39] EXPECT_NS_END
+// [39] EXPECT_NS_END invert
 //
-//        expected.pop();
+//        value = expected.pop();
+//        if (value.pos === expected.top().pos) {
+//          if (invert) {
+//            value.variants.forEach(e => { e.not = !e.not; });
+//          }
+//          expected.top().variants.pushAll(value.variants);
+//        }
 function generateBytecode( ast ) {
 
     const consts = [];
@@ -265,7 +271,7 @@ function generateBytecode( ast ) {
                 env: cloneEnv( context.env ),
                 action: null
             } ),
-            [ op.EXPECT_NS_END ],
+            [ op.EXPECT_NS_END, negative ? 1 : 0 ],
             buildCondition(
                 [ negative ? op.IF_ERROR : op.IF_NOT_ERROR ],
                 buildSequence(

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -431,9 +431,9 @@ function generateJS( ast, options ) {
             "          ip++;",
             "          break;",
             "",
-            "        case " + op.EXPECT_NS_END + ":",      // EXPECT_NS_END
-            "          peg$end();",
-            "          ip++;",
+            "        case " + op.EXPECT_NS_END + ":",      // EXPECT_NS_END invert
+            "          peg$end(bc[ip + 1]);",
+            "          ip += 2;",
             "          break;",
             "",
             "        // istanbul ignore next",
@@ -796,9 +796,9 @@ function generateJS( ast, options ) {
                         ip++;
                         break;
 
-                    case op.EXPECT_NS_END:      // EXPECT_NS_END
-                        parts.push( "peg$end();" );
-                        ip++;
+                    case op.EXPECT_NS_END:      // EXPECT_NS_END invert
+                        parts.push( "peg$end(" + ( bc[ ip + 1 ] !== 0 ) + ");" );
+                        ip += 2;
                         break;
 
                     // istanbul ignore next
@@ -899,6 +899,10 @@ function generateJS( ast, options ) {
             "",
             "    other: function(expectation) {",
             "      return expectation.description;",
+            "    },",
+            "",
+            "    not: function(expectation) {",
+            "      return \"not \" + describeExpectation(expectation.expected);",
             "    }",
             "  };",
             "",
@@ -1280,8 +1284,20 @@ function generateJS( ast, options ) {
             "    top.variants.push(expected);",
             "  }",
             "",
-            "  function peg$end() {",
-            "    peg$expected.pop();",
+            "  function peg$end(invert) {",
+            "    var expected = peg$expected.pop();",
+            "    var top = peg$expected[peg$expected.length - 1];",
+            "    var variants = expected.variants;",
+            "",
+            "    if (top.pos !== expected.pos) { return; }",
+            "",
+            "    if (invert) {",
+            "      variants = variants.map(function(e) {",
+            "        return e.type === \"not\" ? e.expected : { type: \"not\", expected: e };",
+            "      });",
+            "    }",
+            "",
+            "    Array.prototype.push.apply(top.variants, variants);",
             "  }",
             "",
             "  function peg$buildSimpleError(message, location) {",

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -391,10 +391,9 @@ function generateJS( ast, options ) {
             "          ip += 2;",
             "          break;",
             "",
-            "        case " + op.FAIL + ":",               // FAIL e
-            "          stack.push(peg$FAILED);",
+            "        case " + op.EXPECT + ":",             // EXPECT e
             "          if (peg$silentFails === 0) {",
-            "            peg$fail(peg$consts[bc[ip + 1]]);",
+            "            peg$expect(peg$consts[bc[ip + 1]]);",
             "          }",
             "          ip += 2;",
             "          break;",
@@ -748,9 +747,8 @@ function generateJS( ast, options ) {
                         ip += 2;
                         break;
 
-                    case op.FAIL:               // FAIL e
-                        parts.push( stack.push( "peg$FAILED" ) );
-                        parts.push( "if (peg$silentFails === 0) { peg$fail(" + c( bc[ ip + 1 ] ) + "); }" );
+                    case op.EXPECT:             // EXPECT e
+                        parts.push( "if (peg$silentFails === 0) { peg$expect(" + c( bc[ ip + 1 ] ) + "); }" );
                         ip += 2;
                         break;
 
@@ -1246,7 +1244,7 @@ function generateJS( ast, options ) {
             "    };",
             "  }",
             "",
-            "  function peg$fail(expected) {",
+            "  function peg$expect(expected) {",
             "    if (peg$currPos < peg$maxFailPos) { return; }",
             "",
             "    if (peg$currPos > peg$maxFailPos) {",
@@ -1311,7 +1309,7 @@ function generateJS( ast, options ) {
             "    return peg$result;",
             "  } else {",
             "    if (peg$result !== peg$FAILED && peg$currPos < input.length) {",
-            "      peg$fail(peg$endExpectation());",
+            "      peg$expect(peg$endExpectation());",
             "    }",
             "",
             "    throw peg$buildStructuredError(",

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -426,6 +426,16 @@ function generateJS( ast, options ) {
             "          ip++;",
             "          break;",
             "",
+            "        case " + op.EXPECT_NS_BEGIN + ":",    // EXPECT_NS_BEGIN
+            "          peg$begin();",
+            "          ip++;",
+            "          break;",
+            "",
+            "        case " + op.EXPECT_NS_END + ":",      // EXPECT_NS_END
+            "          peg$end();",
+            "          ip++;",
+            "          break;",
+            "",
             "        // istanbul ignore next",
             "        default:",
             "          throw new Error(\"Invalid opcode: \" + bc[ip] + \".\");",
@@ -781,6 +791,16 @@ function generateJS( ast, options ) {
                         ip++;
                         break;
 
+                    case op.EXPECT_NS_BEGIN:    // EXPECT_NS_BEGIN
+                        parts.push( "peg$begin();" );
+                        ip++;
+                        break;
+
+                    case op.EXPECT_NS_END:      // EXPECT_NS_END
+                        parts.push( "peg$end();" );
+                        ip++;
+                        break;
+
                     // istanbul ignore next
                     default:
                         throw new Error( "Invalid opcode: " + bc[ ip ] + "." );
@@ -1063,8 +1083,7 @@ function generateJS( ast, options ) {
             "  var peg$currPos = 0;",
             "  var peg$savedPos = 0;",
             "  var peg$posDetailsCache = [{ line: 1, column: 1 }];",
-            "  var peg$maxFailPos = 0;",
-            "  var peg$maxFailExpected = [];",
+            "  var peg$expected = [];",
             "  var peg$silentFails = 0;",   // 0 = report failures, > 0 = silence failures
             ""
         ].join( "\n" ) );
@@ -1244,15 +1263,25 @@ function generateJS( ast, options ) {
             "    };",
             "  }",
             "",
-            "  function peg$expect(expected) {",
-            "    if (peg$currPos < peg$maxFailPos) { return; }",
+            "  function peg$begin() {",
+            "    peg$expected.push({ pos: peg$currPos, variants: [] });",
+            "  }",
             "",
-            "    if (peg$currPos > peg$maxFailPos) {",
-            "      peg$maxFailPos = peg$currPos;",
-            "      peg$maxFailExpected = [];",
+            "  function peg$expect(expected) {",
+            "    var top = peg$expected[peg$expected.length - 1];",
+            "",
+            "    if (peg$currPos < top.pos) { return; }",
+            "",
+            "    if (peg$currPos > top.pos) {",
+            "      top.pos = peg$currPos;",
+            "      top.variants = [];",
             "    }",
             "",
-            "    peg$maxFailExpected.push(expected);",
+            "    top.variants.push(expected);",
+            "  }",
+            "",
+            "  function peg$end() {",
+            "    peg$expected.pop();",
             "  }",
             "",
             "  function peg$buildSimpleError(message, location) {",
@@ -1265,6 +1294,19 @@ function generateJS( ast, options ) {
             "      expected,",
             "      found,",
             "      location",
+            "    );",
+            "  }",
+            "",
+            "  function peg$buildError() {",
+            "    var expected = peg$expected[0];",
+            "    var failPos = expected.pos;",
+            "",
+            "    return peg$buildStructuredError(",
+            "      expected.variants,",
+            "      failPos < input.length ? input.charAt(failPos) : null,",
+            "      failPos < input.length",
+            "        ? peg$computeLocation(failPos, failPos + 1)",
+            "        : peg$computeLocation(failPos, failPos)",
             "    );",
             "  }",
             ""
@@ -1293,6 +1335,8 @@ function generateJS( ast, options ) {
 
         }
 
+        parts.push( "  peg$begin();" );
+
         if ( options.optimize === "size" ) {
 
             parts.push( "  peg$result = peg$parseRule(peg$startRuleIndex);" );
@@ -1312,13 +1356,7 @@ function generateJS( ast, options ) {
             "      peg$expect(peg$endExpectation());",
             "    }",
             "",
-            "    throw peg$buildStructuredError(",
-            "      peg$maxFailExpected,",
-            "      peg$maxFailPos < input.length ? input.charAt(peg$maxFailPos) : null,",
-            "      peg$maxFailPos < input.length",
-            "        ? peg$computeLocation(peg$maxFailPos, peg$maxFailPos + 1)",
-            "        : peg$computeLocation(peg$maxFailPos, peg$maxFailPos)",
-            "    );",
+            "    throw peg$buildError();",
             "  }",
             "}"
         ].join( "\n" ) );

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -51,6 +51,10 @@ peg$SyntaxError.buildMessage = function(expected, found) {
 
     other: function(expectation) {
       return expectation.description;
+    },
+
+    not: function(expectation) {
+      return "not " + describeExpectation(expectation.expected);
     }
   };
 
@@ -486,8 +490,7 @@ function peg$parse(input, options) {
   var peg$currPos = 0;
   var peg$savedPos = 0;
   var peg$posDetailsCache = [{ line: 1, column: 1 }];
-  var peg$maxFailPos = 0;
-  var peg$maxFailExpected = [];
+  var peg$expected = [];
   var peg$silentFails = 0;
 
   var peg$result;
@@ -609,15 +612,37 @@ function peg$parse(input, options) {
     };
   }
 
-  function peg$fail(expected) {
-    if (peg$currPos < peg$maxFailPos) { return; }
+  function peg$begin() {
+    peg$expected.push({ pos: peg$currPos, variants: [] });
+  }
 
-    if (peg$currPos > peg$maxFailPos) {
-      peg$maxFailPos = peg$currPos;
-      peg$maxFailExpected = [];
+  function peg$expect(expected) {
+    var top = peg$expected[peg$expected.length - 1];
+
+    if (peg$currPos < top.pos) { return; }
+
+    if (peg$currPos > top.pos) {
+      top.pos = peg$currPos;
+      top.variants = [];
     }
 
-    peg$maxFailExpected.push(expected);
+    top.variants.push(expected);
+  }
+
+  function peg$end(invert) {
+    var expected = peg$expected.pop();
+    var top = peg$expected[peg$expected.length - 1];
+    var variants = expected.variants;
+
+    if (top.pos !== expected.pos) { return; }
+
+    if (invert) {
+      variants = variants.map(function(e) {
+        return e.type === "not" ? e.expected : { type: "not", expected: e };
+      });
+    }
+
+    Array.prototype.push.apply(top.variants, variants);
   }
 
   function peg$buildSimpleError(message, location) {
@@ -630,6 +655,19 @@ function peg$parse(input, options) {
       expected,
       found,
       location
+    );
+  }
+
+  function peg$buildError() {
+    var expected = peg$expected[0];
+    var failPos = expected.pos;
+
+    return peg$buildStructuredError(
+      expected.variants,
+      failPos < input.length ? input.charAt(failPos) : null,
+      failPos < input.length
+        ? peg$computeLocation(failPos, failPos + 1)
+        : peg$computeLocation(failPos, failPos)
     );
   }
 
@@ -764,12 +802,12 @@ function peg$parse(input, options) {
           s3 = null;
         }
         if (s3 !== peg$FAILED) {
+          if (peg$silentFails === 0) { peg$expect(peg$c3); }
           if (input.charCodeAt(peg$currPos) === 61) {
             s4 = peg$c2;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c3); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -822,12 +860,12 @@ function peg$parse(input, options) {
       s3 = peg$currPos;
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
+        if (peg$silentFails === 0) { peg$expect(peg$c6); }
         if (input.charCodeAt(peg$currPos) === 47) {
           s5 = peg$c5;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c6); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -857,12 +895,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
+          if (peg$silentFails === 0) { peg$expect(peg$c6); }
           if (input.charCodeAt(peg$currPos) === 47) {
             s5 = peg$c5;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c6); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -1005,12 +1043,12 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
+        if (peg$silentFails === 0) { peg$expect(peg$c11); }
         if (input.charCodeAt(peg$currPos) === 58) {
           s3 = peg$c10;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c11); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -1080,28 +1118,28 @@ function peg$parse(input, options) {
   function peg$parsePrefixedOperator() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c15); }
     if (input.charCodeAt(peg$currPos) === 36) {
       s0 = peg$c14;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c15); }
     }
     if (s0 === peg$FAILED) {
+      if (peg$silentFails === 0) { peg$expect(peg$c17); }
       if (input.charCodeAt(peg$currPos) === 38) {
         s0 = peg$c16;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c17); }
       }
       if (s0 === peg$FAILED) {
+        if (peg$silentFails === 0) { peg$expect(peg$c19); }
         if (input.charCodeAt(peg$currPos) === 33) {
           s0 = peg$c18;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c19); }
         }
       }
     }
@@ -1143,28 +1181,28 @@ function peg$parse(input, options) {
   function peg$parseSuffixedOperator() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c22); }
     if (input.charCodeAt(peg$currPos) === 63) {
       s0 = peg$c21;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c22); }
     }
     if (s0 === peg$FAILED) {
+      if (peg$silentFails === 0) { peg$expect(peg$c24); }
       if (input.charCodeAt(peg$currPos) === 42) {
         s0 = peg$c23;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c24); }
       }
       if (s0 === peg$FAILED) {
+        if (peg$silentFails === 0) { peg$expect(peg$c26); }
         if (input.charCodeAt(peg$currPos) === 43) {
           s0 = peg$c25;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c26); }
         }
       }
     }
@@ -1186,12 +1224,12 @@ function peg$parse(input, options) {
             s0 = peg$parseSemanticPredicateExpression();
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
+              if (peg$silentFails === 0) { peg$expect(peg$c28); }
               if (input.charCodeAt(peg$currPos) === 40) {
                 s1 = peg$c27;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c28); }
               }
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse__();
@@ -1200,12 +1238,12 @@ function peg$parse(input, options) {
                   if (s3 !== peg$FAILED) {
                     s4 = peg$parse__();
                     if (s4 !== peg$FAILED) {
+                      if (peg$silentFails === 0) { peg$expect(peg$c30); }
                       if (input.charCodeAt(peg$currPos) === 41) {
                         s5 = peg$c29;
                         peg$currPos++;
                       } else {
                         s5 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c30); }
                       }
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s0;
@@ -1246,7 +1284,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$currPos;
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
@@ -1269,12 +1307,12 @@ function peg$parse(input, options) {
           s5 = null;
         }
         if (s5 !== peg$FAILED) {
+          if (peg$silentFails === 0) { peg$expect(peg$c3); }
           if (input.charCodeAt(peg$currPos) === 61) {
             s6 = peg$c2;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c3); }
           }
           if (s6 !== peg$FAILED) {
             s4 = [s4, s5, s6];
@@ -1291,7 +1329,7 @@ function peg$parse(input, options) {
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -1344,20 +1382,20 @@ function peg$parse(input, options) {
   function peg$parseSemanticPredicateOperator() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c17); }
     if (input.charCodeAt(peg$currPos) === 38) {
       s0 = peg$c16;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c17); }
     }
     if (s0 === peg$FAILED) {
+      if (peg$silentFails === 0) { peg$expect(peg$c19); }
       if (input.charCodeAt(peg$currPos) === 33) {
         s0 = peg$c18;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c19); }
       }
     }
 
@@ -1367,67 +1405,68 @@ function peg$parse(input, options) {
   function peg$parseSourceCharacter() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c34); }
     if (input.length > peg$currPos) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c34); }
     }
 
     return s0;
   }
 
   function peg$parseWhiteSpace() {
-    var s0, s1;
+    var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c35); }
     peg$silentFails++;
+    if (peg$silentFails === 0) { peg$expect(peg$c37); }
     if (input.charCodeAt(peg$currPos) === 9) {
       s0 = peg$c36;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c37); }
     }
     if (s0 === peg$FAILED) {
+      if (peg$silentFails === 0) { peg$expect(peg$c39); }
       if (input.charCodeAt(peg$currPos) === 11) {
         s0 = peg$c38;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c39); }
       }
       if (s0 === peg$FAILED) {
+        if (peg$silentFails === 0) { peg$expect(peg$c41); }
         if (input.charCodeAt(peg$currPos) === 12) {
           s0 = peg$c40;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c41); }
         }
         if (s0 === peg$FAILED) {
+          if (peg$silentFails === 0) { peg$expect(peg$c43); }
           if (input.charCodeAt(peg$currPos) === 32) {
             s0 = peg$c42;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c43); }
           }
           if (s0 === peg$FAILED) {
+            if (peg$silentFails === 0) { peg$expect(peg$c45); }
             if (input.charCodeAt(peg$currPos) === 160) {
               s0 = peg$c44;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c45); }
             }
             if (s0 === peg$FAILED) {
+              if (peg$silentFails === 0) { peg$expect(peg$c47); }
               if (input.charCodeAt(peg$currPos) === 65279) {
                 s0 = peg$c46;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c47); }
               }
               if (s0 === peg$FAILED) {
                 s0 = peg$parseZs();
@@ -1438,10 +1477,6 @@ function peg$parse(input, options) {
       }
     }
     peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c35); }
-    }
 
     return s0;
   }
@@ -1449,86 +1484,80 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c49); }
     if (peg$c48.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
 
     return s0;
   }
 
   function peg$parseLineTerminatorSequence() {
-    var s0, s1;
+    var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c50); }
     peg$silentFails++;
+    if (peg$silentFails === 0) { peg$expect(peg$c52); }
     if (input.charCodeAt(peg$currPos) === 10) {
       s0 = peg$c51;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c52); }
     }
     if (s0 === peg$FAILED) {
+      if (peg$silentFails === 0) { peg$expect(peg$c54); }
       if (input.substr(peg$currPos, 2) === peg$c53) {
         s0 = peg$c53;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c54); }
       }
       if (s0 === peg$FAILED) {
+        if (peg$silentFails === 0) { peg$expect(peg$c56); }
         if (input.charCodeAt(peg$currPos) === 13) {
           s0 = peg$c55;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c56); }
         }
         if (s0 === peg$FAILED) {
+          if (peg$silentFails === 0) { peg$expect(peg$c58); }
           if (input.charCodeAt(peg$currPos) === 8232) {
             s0 = peg$c57;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c58); }
           }
           if (s0 === peg$FAILED) {
+            if (peg$silentFails === 0) { peg$expect(peg$c60); }
             if (input.charCodeAt(peg$currPos) === 8233) {
               s0 = peg$c59;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c60); }
             }
           }
         }
       }
     }
     peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c50); }
-    }
 
     return s0;
   }
 
   function peg$parseComment() {
-    var s0, s1;
+    var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c61); }
     peg$silentFails++;
     s0 = peg$parseMultiLineComment();
     if (s0 === peg$FAILED) {
       s0 = peg$parseSingleLineComment();
     }
     peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c61); }
-    }
 
     return s0;
   }
@@ -1537,26 +1566,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c63); }
     if (input.substr(peg$currPos, 2) === peg$c62) {
       s1 = peg$c62;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c63); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
+      if (peg$silentFails === 0) { peg$expect(peg$c65); }
       if (input.substr(peg$currPos, 2) === peg$c64) {
         s5 = peg$c64;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c65); }
       }
-      peg$silentFails--;
+      peg$end(true);
       if (s5 === peg$FAILED) {
         s4 = undefined;
       } else {
@@ -1580,15 +1609,15 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         s4 = peg$currPos;
-        peg$silentFails++;
+        peg$begin();
+        if (peg$silentFails === 0) { peg$expect(peg$c65); }
         if (input.substr(peg$currPos, 2) === peg$c64) {
           s5 = peg$c64;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
         }
-        peg$silentFails--;
+        peg$end(true);
         if (s5 === peg$FAILED) {
           s4 = undefined;
         } else {
@@ -1610,12 +1639,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
+        if (peg$silentFails === 0) { peg$expect(peg$c65); }
         if (input.substr(peg$currPos, 2) === peg$c64) {
           s3 = peg$c64;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -1640,29 +1669,29 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c63); }
     if (input.substr(peg$currPos, 2) === peg$c62) {
       s1 = peg$c62;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c63); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
+      if (peg$silentFails === 0) { peg$expect(peg$c65); }
       if (input.substr(peg$currPos, 2) === peg$c64) {
         s5 = peg$c64;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c65); }
       }
       if (s5 === peg$FAILED) {
         s5 = peg$parseLineTerminator();
       }
-      peg$silentFails--;
+      peg$end(true);
       if (s5 === peg$FAILED) {
         s4 = undefined;
       } else {
@@ -1686,18 +1715,18 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         s4 = peg$currPos;
-        peg$silentFails++;
+        peg$begin();
+        if (peg$silentFails === 0) { peg$expect(peg$c65); }
         if (input.substr(peg$currPos, 2) === peg$c64) {
           s5 = peg$c64;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
         }
         if (s5 === peg$FAILED) {
           s5 = peg$parseLineTerminator();
         }
-        peg$silentFails--;
+        peg$end(true);
         if (s5 === peg$FAILED) {
           s4 = undefined;
         } else {
@@ -1719,12 +1748,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
+        if (peg$silentFails === 0) { peg$expect(peg$c65); }
         if (input.substr(peg$currPos, 2) === peg$c64) {
           s3 = peg$c64;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -1749,20 +1778,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c67); }
     if (input.substr(peg$currPos, 2) === peg$c66) {
       s1 = peg$c66;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c67); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s5 = peg$parseLineTerminator();
-      peg$silentFails--;
+      peg$end(true);
       if (s5 === peg$FAILED) {
         s4 = undefined;
       } else {
@@ -1786,9 +1815,9 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         s4 = peg$currPos;
-        peg$silentFails++;
+        peg$begin();
         s5 = peg$parseLineTerminator();
-        peg$silentFails--;
+        peg$end(true);
         if (s5 === peg$FAILED) {
           s4 = undefined;
         } else {
@@ -1829,9 +1858,9 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    peg$silentFails++;
+    peg$begin();
     s2 = peg$parseReservedWord();
-    peg$silentFails--;
+    peg$end(true);
     if (s2 === peg$FAILED) {
       s1 = undefined;
     } else {
@@ -1858,6 +1887,7 @@ function peg$parse(input, options) {
   function peg$parseIdentifierName() {
     var s0, s1, s2, s3;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c69); }
     peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parseIdentifierStart();
@@ -1880,10 +1910,6 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c69); }
-    }
 
     return s0;
   }
@@ -1893,29 +1919,29 @@ function peg$parse(input, options) {
 
     s0 = peg$parseUnicodeLetter();
     if (s0 === peg$FAILED) {
+      if (peg$silentFails === 0) { peg$expect(peg$c15); }
       if (input.charCodeAt(peg$currPos) === 36) {
         s0 = peg$c14;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c15); }
       }
       if (s0 === peg$FAILED) {
+        if (peg$silentFails === 0) { peg$expect(peg$c72); }
         if (input.charCodeAt(peg$currPos) === 95) {
           s0 = peg$c71;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c72); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
+          if (peg$silentFails === 0) { peg$expect(peg$c74); }
           if (input.charCodeAt(peg$currPos) === 92) {
             s1 = peg$c73;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseUnicodeEscapeSequence();
@@ -1948,20 +1974,20 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$parsePc();
           if (s0 === peg$FAILED) {
+            if (peg$silentFails === 0) { peg$expect(peg$c77); }
             if (input.charCodeAt(peg$currPos) === 8204) {
               s0 = peg$c76;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c77); }
             }
             if (s0 === peg$FAILED) {
+              if (peg$silentFails === 0) { peg$expect(peg$c79); }
               if (input.charCodeAt(peg$currPos) === 8205) {
                 s0 = peg$c78;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c79); }
               }
             }
           }
@@ -2146,16 +2172,17 @@ function peg$parse(input, options) {
   function peg$parseLiteralMatcher() {
     var s0, s1, s2;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c80); }
     peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parseStringLiteral();
     if (s1 !== peg$FAILED) {
+      if (peg$silentFails === 0) { peg$expect(peg$c82); }
       if (input.charCodeAt(peg$currPos) === 105) {
         s2 = peg$c81;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c82); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -2172,10 +2199,6 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c80); }
-    }
 
     return s0;
   }
@@ -2183,14 +2206,15 @@ function peg$parse(input, options) {
   function peg$parseStringLiteral() {
     var s0, s1, s2, s3;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c84); }
     peg$silentFails++;
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c86); }
     if (input.charCodeAt(peg$currPos) === 34) {
       s1 = peg$c85;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c86); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -2200,12 +2224,12 @@ function peg$parse(input, options) {
         s3 = peg$parseDoubleStringCharacter();
       }
       if (s2 !== peg$FAILED) {
+        if (peg$silentFails === 0) { peg$expect(peg$c86); }
         if (input.charCodeAt(peg$currPos) === 34) {
           s3 = peg$c85;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c86); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -2224,12 +2248,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
+      if (peg$silentFails === 0) { peg$expect(peg$c89); }
       if (input.charCodeAt(peg$currPos) === 39) {
         s1 = peg$c88;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c89); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -2239,12 +2263,12 @@ function peg$parse(input, options) {
           s3 = peg$parseSingleStringCharacter();
         }
         if (s2 !== peg$FAILED) {
+          if (peg$silentFails === 0) { peg$expect(peg$c89); }
           if (input.charCodeAt(peg$currPos) === 39) {
             s3 = peg$c88;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c89); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -2263,10 +2287,6 @@ function peg$parse(input, options) {
       }
     }
     peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c84); }
-    }
 
     return s0;
   }
@@ -2276,27 +2296,27 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    peg$silentFails++;
+    peg$begin();
+    if (peg$silentFails === 0) { peg$expect(peg$c86); }
     if (input.charCodeAt(peg$currPos) === 34) {
       s2 = peg$c85;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c86); }
     }
     if (s2 === peg$FAILED) {
+      if (peg$silentFails === 0) { peg$expect(peg$c74); }
       if (input.charCodeAt(peg$currPos) === 92) {
         s2 = peg$c73;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parseLineTerminator();
       }
     }
-    peg$silentFails--;
+    peg$end(true);
     if (s2 === peg$FAILED) {
       s1 = undefined;
     } else {
@@ -2318,12 +2338,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
+      if (peg$silentFails === 0) { peg$expect(peg$c74); }
       if (input.charCodeAt(peg$currPos) === 92) {
         s1 = peg$c73;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -2351,27 +2371,27 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    peg$silentFails++;
+    peg$begin();
+    if (peg$silentFails === 0) { peg$expect(peg$c89); }
     if (input.charCodeAt(peg$currPos) === 39) {
       s2 = peg$c88;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c89); }
     }
     if (s2 === peg$FAILED) {
+      if (peg$silentFails === 0) { peg$expect(peg$c74); }
       if (input.charCodeAt(peg$currPos) === 92) {
         s2 = peg$c73;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parseLineTerminator();
       }
     }
-    peg$silentFails--;
+    peg$end(true);
     if (s2 === peg$FAILED) {
       s1 = undefined;
     } else {
@@ -2393,12 +2413,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
+      if (peg$silentFails === 0) { peg$expect(peg$c74); }
       if (input.charCodeAt(peg$currPos) === 92) {
         s1 = peg$c73;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -2424,22 +2444,23 @@ function peg$parse(input, options) {
   function peg$parseCharacterClassMatcher() {
     var s0, s1, s2, s3, s4, s5;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c91); }
     peg$silentFails++;
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c93); }
     if (input.charCodeAt(peg$currPos) === 91) {
       s1 = peg$c92;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c93); }
     }
     if (s1 !== peg$FAILED) {
+      if (peg$silentFails === 0) { peg$expect(peg$c95); }
       if (input.charCodeAt(peg$currPos) === 94) {
         s2 = peg$c94;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c95); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -2458,20 +2479,20 @@ function peg$parse(input, options) {
           }
         }
         if (s3 !== peg$FAILED) {
+          if (peg$silentFails === 0) { peg$expect(peg$c97); }
           if (input.charCodeAt(peg$currPos) === 93) {
             s4 = peg$c96;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c97); }
           }
           if (s4 !== peg$FAILED) {
+            if (peg$silentFails === 0) { peg$expect(peg$c82); }
             if (input.charCodeAt(peg$currPos) === 105) {
               s5 = peg$c81;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c82); }
             }
             if (s5 === peg$FAILED) {
               s5 = null;
@@ -2500,10 +2521,6 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c91); }
-    }
 
     return s0;
   }
@@ -2514,12 +2531,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseClassCharacter();
     if (s1 !== peg$FAILED) {
+      if (peg$silentFails === 0) { peg$expect(peg$c100); }
       if (input.charCodeAt(peg$currPos) === 45) {
         s2 = peg$c99;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c100); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseClassCharacter();
@@ -2547,27 +2564,27 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    peg$silentFails++;
+    peg$begin();
+    if (peg$silentFails === 0) { peg$expect(peg$c97); }
     if (input.charCodeAt(peg$currPos) === 93) {
       s2 = peg$c96;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c97); }
     }
     if (s2 === peg$FAILED) {
+      if (peg$silentFails === 0) { peg$expect(peg$c74); }
       if (input.charCodeAt(peg$currPos) === 92) {
         s2 = peg$c73;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parseLineTerminator();
       }
     }
-    peg$silentFails--;
+    peg$end(true);
     if (s2 === peg$FAILED) {
       s1 = undefined;
     } else {
@@ -2589,12 +2606,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
+      if (peg$silentFails === 0) { peg$expect(peg$c74); }
       if (input.charCodeAt(peg$currPos) === 92) {
         s1 = peg$c73;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -2621,12 +2638,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c74); }
     if (input.charCodeAt(peg$currPos) === 92) {
       s1 = peg$c73;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c74); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseLineTerminatorSequence();
@@ -2651,18 +2668,18 @@ function peg$parse(input, options) {
     s0 = peg$parseCharacterEscapeSequence();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
+      if (peg$silentFails === 0) { peg$expect(peg$c104); }
       if (input.charCodeAt(peg$currPos) === 48) {
         s1 = peg$c103;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c104); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
-        peg$silentFails++;
+        peg$begin();
         s3 = peg$parseDecimalDigit();
-        peg$silentFails--;
+        peg$end(true);
         if (s3 === peg$FAILED) {
           s2 = undefined;
         } else {
@@ -2705,37 +2722,37 @@ function peg$parse(input, options) {
   function peg$parseSingleEscapeCharacter() {
     var s0, s1;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c89); }
     if (input.charCodeAt(peg$currPos) === 39) {
       s0 = peg$c88;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c89); }
     }
     if (s0 === peg$FAILED) {
+      if (peg$silentFails === 0) { peg$expect(peg$c86); }
       if (input.charCodeAt(peg$currPos) === 34) {
         s0 = peg$c85;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
       }
       if (s0 === peg$FAILED) {
+        if (peg$silentFails === 0) { peg$expect(peg$c74); }
         if (input.charCodeAt(peg$currPos) === 92) {
           s0 = peg$c73;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
+          if (peg$silentFails === 0) { peg$expect(peg$c107); }
           if (input.charCodeAt(peg$currPos) === 98) {
             s1 = peg$c106;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c107); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -2744,12 +2761,12 @@ function peg$parse(input, options) {
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
+            if (peg$silentFails === 0) { peg$expect(peg$c110); }
             if (input.charCodeAt(peg$currPos) === 102) {
               s1 = peg$c109;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c110); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
@@ -2758,12 +2775,12 @@ function peg$parse(input, options) {
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
+              if (peg$silentFails === 0) { peg$expect(peg$c113); }
               if (input.charCodeAt(peg$currPos) === 110) {
                 s1 = peg$c112;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c113); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
@@ -2772,12 +2789,12 @@ function peg$parse(input, options) {
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
+                if (peg$silentFails === 0) { peg$expect(peg$c116); }
                 if (input.charCodeAt(peg$currPos) === 114) {
                   s1 = peg$c115;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c116); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
@@ -2786,12 +2803,12 @@ function peg$parse(input, options) {
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
+                  if (peg$silentFails === 0) { peg$expect(peg$c119); }
                   if (input.charCodeAt(peg$currPos) === 116) {
                     s1 = peg$c118;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c119); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
@@ -2800,12 +2817,12 @@ function peg$parse(input, options) {
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
+                    if (peg$silentFails === 0) { peg$expect(peg$c122); }
                     if (input.charCodeAt(peg$currPos) === 118) {
                       s1 = peg$c121;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c122); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
@@ -2829,12 +2846,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    peg$silentFails++;
+    peg$begin();
     s2 = peg$parseEscapeCharacter();
     if (s2 === peg$FAILED) {
       s2 = peg$parseLineTerminator();
     }
-    peg$silentFails--;
+    peg$end(true);
     if (s2 === peg$FAILED) {
       s1 = undefined;
     } else {
@@ -2865,20 +2882,20 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$parseDecimalDigit();
       if (s0 === peg$FAILED) {
+        if (peg$silentFails === 0) { peg$expect(peg$c125); }
         if (input.charCodeAt(peg$currPos) === 120) {
           s0 = peg$c124;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c125); }
         }
         if (s0 === peg$FAILED) {
+          if (peg$silentFails === 0) { peg$expect(peg$c127); }
           if (input.charCodeAt(peg$currPos) === 117) {
             s0 = peg$c126;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c127); }
           }
         }
       }
@@ -2891,12 +2908,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c125); }
     if (input.charCodeAt(peg$currPos) === 120) {
       s1 = peg$c124;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c125); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -2939,12 +2956,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c127); }
     if (input.charCodeAt(peg$currPos) === 117) {
       s1 = peg$c126;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c127); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -2998,12 +3015,12 @@ function peg$parse(input, options) {
   function peg$parseDecimalDigit() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c130); }
     if (peg$c129.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c130); }
     }
 
     return s0;
@@ -3012,12 +3029,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c132); }
     if (peg$c131.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c132); }
     }
 
     return s0;
@@ -3027,12 +3044,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c134); }
     if (input.charCodeAt(peg$currPos) === 46) {
       s1 = peg$c133;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c134); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -3046,24 +3063,25 @@ function peg$parse(input, options) {
   function peg$parseCodeBlock() {
     var s0, s1, s2, s3;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c136); }
     peg$silentFails++;
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c138); }
     if (input.charCodeAt(peg$currPos) === 123) {
       s1 = peg$c137;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c138); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseCode();
       if (s2 !== peg$FAILED) {
+        if (peg$silentFails === 0) { peg$expect(peg$c140); }
         if (input.charCodeAt(peg$currPos) === 125) {
           s3 = peg$c139;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c140); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -3082,12 +3100,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
+      if (peg$silentFails === 0) { peg$expect(peg$c138); }
       if (input.charCodeAt(peg$currPos) === 123) {
         s1 = peg$c137;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c138); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -3096,10 +3114,6 @@ function peg$parse(input, options) {
       s0 = s1;
     }
     peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c136); }
-    }
 
     return s0;
   }
@@ -3112,15 +3126,15 @@ function peg$parse(input, options) {
     s2 = [];
     s3 = peg$currPos;
     s4 = peg$currPos;
-    peg$silentFails++;
+    peg$begin();
+    if (peg$silentFails === 0) { peg$expect(peg$c144); }
     if (peg$c143.test(input.charAt(peg$currPos))) {
       s5 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s5 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c144); }
     }
-    peg$silentFails--;
+    peg$end(true);
     if (s5 === peg$FAILED) {
       s4 = undefined;
     } else {
@@ -3145,15 +3159,15 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         s4 = peg$currPos;
-        peg$silentFails++;
+        peg$begin();
+        if (peg$silentFails === 0) { peg$expect(peg$c144); }
         if (peg$c143.test(input.charAt(peg$currPos))) {
           s5 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c144); }
         }
-        peg$silentFails--;
+        peg$end(true);
         if (s5 === peg$FAILED) {
           s4 = undefined;
         } else {
@@ -3179,22 +3193,22 @@ function peg$parse(input, options) {
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
+      if (peg$silentFails === 0) { peg$expect(peg$c138); }
       if (input.charCodeAt(peg$currPos) === 123) {
         s3 = peg$c137;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c138); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parseCode();
         if (s4 !== peg$FAILED) {
+          if (peg$silentFails === 0) { peg$expect(peg$c140); }
           if (input.charCodeAt(peg$currPos) === 125) {
             s5 = peg$c139;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c140); }
           }
           if (s5 !== peg$FAILED) {
             s3 = [s3, s4, s5];
@@ -3217,15 +3231,15 @@ function peg$parse(input, options) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
+      if (peg$silentFails === 0) { peg$expect(peg$c144); }
       if (peg$c143.test(input.charAt(peg$currPos))) {
         s5 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c144); }
       }
-      peg$silentFails--;
+      peg$end(true);
       if (s5 === peg$FAILED) {
         s4 = undefined;
       } else {
@@ -3250,15 +3264,15 @@ function peg$parse(input, options) {
           s2.push(s3);
           s3 = peg$currPos;
           s4 = peg$currPos;
-          peg$silentFails++;
+          peg$begin();
+          if (peg$silentFails === 0) { peg$expect(peg$c144); }
           if (peg$c143.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c144); }
           }
-          peg$silentFails--;
+          peg$end(true);
           if (s5 === peg$FAILED) {
             s4 = undefined;
           } else {
@@ -3284,22 +3298,22 @@ function peg$parse(input, options) {
       }
       if (s2 === peg$FAILED) {
         s2 = peg$currPos;
+        if (peg$silentFails === 0) { peg$expect(peg$c138); }
         if (input.charCodeAt(peg$currPos) === 123) {
           s3 = peg$c137;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c138); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parseCode();
           if (s4 !== peg$FAILED) {
+            if (peg$silentFails === 0) { peg$expect(peg$c140); }
             if (input.charCodeAt(peg$currPos) === 125) {
               s5 = peg$c139;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c140); }
             }
             if (s5 !== peg$FAILED) {
               s3 = [s3, s4, s5];
@@ -3330,12 +3344,12 @@ function peg$parse(input, options) {
   function peg$parseLl() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c146); }
     if (peg$c145.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c146); }
     }
 
     return s0;
@@ -3344,12 +3358,12 @@ function peg$parse(input, options) {
   function peg$parseLm() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c148); }
     if (peg$c147.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
     }
 
     return s0;
@@ -3358,12 +3372,12 @@ function peg$parse(input, options) {
   function peg$parseLo() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c150); }
     if (peg$c149.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c150); }
     }
 
     return s0;
@@ -3372,12 +3386,12 @@ function peg$parse(input, options) {
   function peg$parseLt() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c152); }
     if (peg$c151.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c152); }
     }
 
     return s0;
@@ -3386,12 +3400,12 @@ function peg$parse(input, options) {
   function peg$parseLu() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c154); }
     if (peg$c153.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c154); }
     }
 
     return s0;
@@ -3400,12 +3414,12 @@ function peg$parse(input, options) {
   function peg$parseMc() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c156); }
     if (peg$c155.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c156); }
     }
 
     return s0;
@@ -3414,12 +3428,12 @@ function peg$parse(input, options) {
   function peg$parseMn() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c158); }
     if (peg$c157.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c158); }
     }
 
     return s0;
@@ -3428,12 +3442,12 @@ function peg$parse(input, options) {
   function peg$parseNd() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c160); }
     if (peg$c159.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c160); }
     }
 
     return s0;
@@ -3442,12 +3456,12 @@ function peg$parse(input, options) {
   function peg$parseNl() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c162); }
     if (peg$c161.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c162); }
     }
 
     return s0;
@@ -3456,12 +3470,12 @@ function peg$parse(input, options) {
   function peg$parsePc() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c164); }
     if (peg$c163.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c164); }
     }
 
     return s0;
@@ -3470,12 +3484,12 @@ function peg$parse(input, options) {
   function peg$parseZs() {
     var s0;
 
+    if (peg$silentFails === 0) { peg$expect(peg$c166); }
     if (peg$c165.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c166); }
     }
 
     return s0;
@@ -3485,18 +3499,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c168); }
     if (input.substr(peg$currPos, 5) === peg$c167) {
       s1 = peg$c167;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c168); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -3522,18 +3536,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c170); }
     if (input.substr(peg$currPos, 4) === peg$c169) {
       s1 = peg$c169;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c170); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -3559,18 +3573,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c172); }
     if (input.substr(peg$currPos, 5) === peg$c171) {
       s1 = peg$c171;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c172); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -3596,18 +3610,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c174); }
     if (input.substr(peg$currPos, 5) === peg$c173) {
       s1 = peg$c173;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c174); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -3633,18 +3647,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c176); }
     if (input.substr(peg$currPos, 5) === peg$c175) {
       s1 = peg$c175;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c176); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -3670,18 +3684,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c178); }
     if (input.substr(peg$currPos, 8) === peg$c177) {
       s1 = peg$c177;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c178); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -3707,18 +3721,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c180); }
     if (input.substr(peg$currPos, 8) === peg$c179) {
       s1 = peg$c179;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c180); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -3744,18 +3758,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c182); }
     if (input.substr(peg$currPos, 7) === peg$c181) {
       s1 = peg$c181;
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c182); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -3781,18 +3795,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c184); }
     if (input.substr(peg$currPos, 6) === peg$c183) {
       s1 = peg$c183;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c184); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -3818,18 +3832,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c186); }
     if (input.substr(peg$currPos, 2) === peg$c185) {
       s1 = peg$c185;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c186); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -3855,18 +3869,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c188); }
     if (input.substr(peg$currPos, 4) === peg$c187) {
       s1 = peg$c187;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c188); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -3892,18 +3906,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c190); }
     if (input.substr(peg$currPos, 4) === peg$c189) {
       s1 = peg$c189;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c190); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -3929,18 +3943,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c192); }
     if (input.substr(peg$currPos, 6) === peg$c191) {
       s1 = peg$c191;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c192); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -3966,18 +3980,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c194); }
     if (input.substr(peg$currPos, 7) === peg$c193) {
       s1 = peg$c193;
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c194); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4003,18 +4017,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c196); }
     if (input.substr(peg$currPos, 5) === peg$c195) {
       s1 = peg$c195;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c196); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4040,18 +4054,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c198); }
     if (input.substr(peg$currPos, 7) === peg$c197) {
       s1 = peg$c197;
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c198); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4077,18 +4091,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c200); }
     if (input.substr(peg$currPos, 3) === peg$c199) {
       s1 = peg$c199;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c200); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4114,18 +4128,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c202); }
     if (input.substr(peg$currPos, 8) === peg$c201) {
       s1 = peg$c201;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c202); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4151,18 +4165,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c204); }
     if (input.substr(peg$currPos, 2) === peg$c203) {
       s1 = peg$c203;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c204); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4188,18 +4202,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c206); }
     if (input.substr(peg$currPos, 6) === peg$c205) {
       s1 = peg$c205;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c206); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4225,18 +4239,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c208); }
     if (input.substr(peg$currPos, 10) === peg$c207) {
       s1 = peg$c207;
       peg$currPos += 10;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c208); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4262,18 +4276,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c210); }
     if (input.substr(peg$currPos, 2) === peg$c209) {
       s1 = peg$c209;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c210); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4299,18 +4313,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c212); }
     if (input.substr(peg$currPos, 3) === peg$c211) {
       s1 = peg$c211;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c212); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4336,18 +4350,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c214); }
     if (input.substr(peg$currPos, 4) === peg$c213) {
       s1 = peg$c213;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c214); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4373,18 +4387,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c216); }
     if (input.substr(peg$currPos, 6) === peg$c215) {
       s1 = peg$c215;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c216); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4410,18 +4424,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c218); }
     if (input.substr(peg$currPos, 5) === peg$c217) {
       s1 = peg$c217;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c218); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4447,18 +4461,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c220); }
     if (input.substr(peg$currPos, 6) === peg$c219) {
       s1 = peg$c219;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c220); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4484,18 +4498,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c222); }
     if (input.substr(peg$currPos, 4) === peg$c221) {
       s1 = peg$c221;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c222); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4521,18 +4535,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c224); }
     if (input.substr(peg$currPos, 5) === peg$c223) {
       s1 = peg$c223;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c224); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4558,18 +4572,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c226); }
     if (input.substr(peg$currPos, 4) === peg$c225) {
       s1 = peg$c225;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c226); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4595,18 +4609,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c228); }
     if (input.substr(peg$currPos, 3) === peg$c227) {
       s1 = peg$c227;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c228); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4632,18 +4646,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c230); }
     if (input.substr(peg$currPos, 6) === peg$c229) {
       s1 = peg$c229;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c230); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4669,18 +4683,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c232); }
     if (input.substr(peg$currPos, 3) === peg$c231) {
       s1 = peg$c231;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c232); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4706,18 +4720,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c234); }
     if (input.substr(peg$currPos, 4) === peg$c233) {
       s1 = peg$c233;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c234); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4743,18 +4757,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c236); }
     if (input.substr(peg$currPos, 5) === peg$c235) {
       s1 = peg$c235;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c236); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4780,18 +4794,18 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
+    if (peg$silentFails === 0) { peg$expect(peg$c238); }
     if (input.substr(peg$currPos, 4) === peg$c237) {
       s1 = peg$c237;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c238); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      peg$silentFails++;
+      peg$begin();
       s3 = peg$parseIdentifierPart();
-      peg$silentFails--;
+      peg$end(true);
       if (s3 === peg$FAILED) {
         s2 = undefined;
       } else {
@@ -4863,12 +4877,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
+      if (peg$silentFails === 0) { peg$expect(peg$c240); }
       if (input.charCodeAt(peg$currPos) === 59) {
         s2 = peg$c239;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c240); }
       }
       if (s2 !== peg$FAILED) {
         s1 = [s1, s2];
@@ -4932,15 +4946,15 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    peg$silentFails++;
+    peg$begin();
+    if (peg$silentFails === 0) { peg$expect(peg$c34); }
     if (input.length > peg$currPos) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c34); }
     }
-    peg$silentFails--;
+    peg$end(true);
     if (s1 === peg$FAILED) {
       s0 = undefined;
     } else {
@@ -4982,22 +4996,17 @@ function peg$parse(input, options) {
     }
 
 
+  peg$begin();
   peg$result = peg$startRuleFunction();
 
   if (peg$result !== peg$FAILED && peg$currPos === input.length) {
     return peg$result;
   } else {
     if (peg$result !== peg$FAILED && peg$currPos < input.length) {
-      peg$fail(peg$endExpectation());
+      peg$expect(peg$endExpectation());
     }
 
-    throw peg$buildStructuredError(
-      peg$maxFailExpected,
-      peg$maxFailPos < input.length ? input.charAt(peg$maxFailPos) : null,
-      peg$maxFailPos < input.length
-        ? peg$computeLocation(peg$maxFailPos, peg$maxFailPos + 1)
-        : peg$computeLocation(peg$maxFailPos, peg$maxFailPos)
-    );
+    throw peg$buildError();
   }
 }
 

--- a/test/spec/behavior/generated-parser-behavior.spec.js
+++ b/test/spec/behavior/generated-parser-behavior.spec.js
@@ -1194,14 +1194,28 @@ describe( "generated parser behavior", function () {
 
                 } );
 
-                it( "discards any expectations recorded when matching the expression", function () {
+                it( "doesn't discard any expectations recorded when matching the expression", function () {
 
                     const parser = peg.generate( "start = 'a' / &'b' / 'c'", options );
 
                     expect( parser ).to.failToParse( "d", {
                         expected: [
                             { type: "literal", text: "a", ignoreCase: false },
+                            { type: "literal", text: "b", ignoreCase: false },
                             { type: "literal", text: "c", ignoreCase: false }
+                        ]
+                    } );
+
+                } );
+
+                it( "records expectations from right place", function () {
+
+                    const parser = peg.generate( "start = 'a' / &'b' .", options );
+
+                    expect( parser ).to.failToParse( "d", {
+                        expected: [
+                            { type: "literal", text: "a", ignoreCase: false },
+                            { type: "literal", text: "b", ignoreCase: false }
                         ]
                     } );
 
@@ -1243,14 +1257,40 @@ describe( "generated parser behavior", function () {
 
                 } );
 
-                it( "discards any expectations recorded when matching the expression", function () {
+                it( "inverts any expectations recorded when matching the expression", function () {
 
                     const parser = peg.generate( "start = 'a' / !'b' / 'c'", options );
 
                     expect( parser ).to.failToParse( "b", {
                         expected: [
                             { type: "literal", text: "a", ignoreCase: false },
+                            { type: "not", expected: { type: "literal", text: "b", ignoreCase: false } },
                             { type: "literal", text: "c", ignoreCase: false }
+                        ]
+                    } );
+
+                } );
+
+                it( "records expectations from right place", function () {
+
+                    const parser = peg.generate( "start = 'a' / !'b' .", options );
+
+                    expect( parser ).to.failToParse( "b", {
+                        expected: [
+                            { type: "literal", text: "a", ignoreCase: false },
+                            { type: "not", expected: { type: "literal", text: "b", ignoreCase: false } }
+                        ]
+                    } );
+
+                } );
+
+                it( "reports not inverted expectations when the expression inverted twice", function () {
+
+                    const parser = peg.generate( "start = !(!'a')", options );
+
+                    expect( parser ).to.failToParse( "b", {
+                        expected: [
+                            { type: "literal", text: "a", ignoreCase: false }
                         ]
                     } );
 

--- a/test/spec/unit/compiler/passes/generate-bytecode.spec.js
+++ b/test/spec/unit/compiler/passes/generate-bytecode.spec.js
@@ -83,9 +83,7 @@ describe( "compiler pass |generateBytecode|", function () {
                 23, 0,                        // EXPECT <0>
                 28,                           // SILENT_FAILS_ON
                 23, 2, 18, 1, 2, 1, 22, 1, 3, // <expression>
-                29,                           // SILENT_FAILS_OFF
-                14, 1, 0,                     // IF_ERROR
-                3                             //   * PUSH_FAILED
+                29                            // SILENT_FAILS_OFF
             ] ) );
 
         } );

--- a/test/spec/unit/compiler/passes/generate-bytecode.spec.js
+++ b/test/spec/unit/compiler/passes/generate-bytecode.spec.js
@@ -34,9 +34,9 @@ describe( "compiler pass |generateBytecode|", function () {
                 "c = 'c'"
             ].join( "\n" ), {
                 rules: [
-                    { bytecode: [ 18, 0, 2, 3, 22, 0, 3, 23, 1 ] },
-                    { bytecode: [ 18, 2, 2, 3, 22, 2, 3, 23, 3 ] },
-                    { bytecode: [ 18, 4, 2, 3, 22, 4, 3, 23, 5 ] }
+                    { bytecode: [ 23, 1, 18, 0, 2, 1, 22, 0, 3 ] },
+                    { bytecode: [ 23, 3, 18, 2, 2, 1, 22, 2, 3 ] },
+                    { bytecode: [ 23, 5, 18, 4, 2, 1, 22, 4, 3 ] }
                 ]
             } );
 
@@ -66,7 +66,7 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( "start = 'a'", bytecodeDetails( [
-                18, 0, 2, 3, 22, 0, 3, 23, 1   // <expression>
+                23, 1, 18, 0, 2, 1, 22, 0, 3   // <expression>
             ] ) );
 
         } );
@@ -80,12 +80,12 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
+                23, 0,                        // EXPECT <0>
                 28,                           // SILENT_FAILS_ON
-                18, 1, 2, 3, 22, 1, 3, 23, 2, // <expression>
+                23, 2, 18, 1, 2, 1, 22, 1, 3, // <expression>
                 29,                           // SILENT_FAILS_OFF
-                14, 3, 0,                     // IF_ERROR
-                3,                            //   * PUSH_FAILED
-                23, 0                         //     EXPECT <0>
+                14, 1, 0,                     // IF_ERROR
+                3                             //   * PUSH_FAILED
             ] ) );
 
         } );
@@ -107,13 +107,13 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( "start = 'a' / 'b' / 'c'", bytecodeDetails( [
-                18, 0, 2, 3, 22, 0, 3, 23, 1, // <alternatives[0]>
+                23, 1, 18, 0, 2, 1, 22, 0, 3, // <alternatives[0]>
                 14, 23, 0,                    // IF_ERROR
                 6,                            //   * POP
-                18, 2, 2, 3, 22, 2, 3, 23, 3, //     <alternatives[1]>
+                23, 3, 18, 2, 2, 1, 22, 2, 3, //     <alternatives[1]>
                 14, 10, 0,                    //     IF_ERROR
                 6,                            //       * POP
-                18, 4, 2, 3, 22, 4, 3, 23, 5  //         <alternatives[2]>
+                23, 5, 18, 4, 2, 1, 22, 4, 3  //         <alternatives[2]>
             ] ) );
 
         } );
@@ -130,7 +130,7 @@ describe( "compiler pass |generateBytecode|", function () {
 
                 expect( pass ).to.changeAST( grammar, bytecodeDetails( [
                     5,                            // PUSH_CURR_POS
-                    18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                    23, 1, 18, 0, 2, 1, 22, 0, 3, // <expression>
                     15, 6, 0,                     // IF_NOT_ERROR
                     24, 1,                        //   * LOAD_SAVED_POS
                     26, 2, 1, 0,                  //     CALL
@@ -159,7 +159,7 @@ describe( "compiler pass |generateBytecode|", function () {
 
                 expect( pass ).to.changeAST( grammar, bytecodeDetails( [
                     5,                            // PUSH_CURR_POS
-                    18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                    23, 1, 18, 0, 2, 1, 22, 0, 3, // <expression>
                     15, 7, 0,                     // IF_NOT_ERROR
                     24, 1,                        //   * LOAD_SAVED_POS
                     26, 2, 1, 1, 0,               //     CALL
@@ -188,11 +188,11 @@ describe( "compiler pass |generateBytecode|", function () {
 
                 expect( pass ).to.changeAST( grammar, bytecodeDetails( [
                     5,                            // PUSH_CURR_POS
-                    18, 0, 2, 3, 22, 0, 3, 23, 1, // <elements[0]>
+                    23, 1, 18, 0, 2, 1, 22, 0, 3, // <elements[0]>
                     15, 41, 3,                    // IF_NOT_ERROR
-                    18, 2, 2, 3, 22, 2, 3, 23, 3, //   * <elements[1]>
+                    23, 3, 18, 2, 2, 1, 22, 2, 3, //   * <elements[1]>
                     15, 25, 4,                    //     IF_NOT_ERROR
-                    18, 4, 2, 3, 22, 4, 3, 23, 5, //       * <elements[2]>
+                    23, 5, 18, 4, 2, 1, 22, 4, 3, //       * <elements[2]>
                     15, 9, 4,                     //         IF_NOT_ERROR
                     24, 3,                        //           * LOAD_SAVED_POS
                     26, 6, 4, 3, 2, 1, 0,         //             CALL <6>
@@ -235,11 +235,11 @@ describe( "compiler pass |generateBytecode|", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
                 5,                            // PUSH_CURR_POS
-                18, 0, 2, 3, 22, 0, 3, 23, 1, // <elements[0]>
+                23, 1, 18, 0, 2, 1, 22, 0, 3, // <elements[0]>
                 15, 35, 3,                    // IF_NOT_ERROR
-                18, 2, 2, 3, 22, 2, 3, 23, 3, //   * <elements[1]>
+                23, 3, 18, 2, 2, 1, 22, 2, 3, //   * <elements[1]>
                 15, 19, 4,                    //     IF_NOT_ERROR
-                18, 4, 2, 3, 22, 4, 3, 23, 5, //       * <elements[2]>
+                23, 5, 18, 4, 2, 1, 22, 4, 3, //       * <elements[2]>
                 15, 3, 4,                     //         IF_NOT_ERROR
                 11, 3,                        //           * WRAP
                 9,                            //             NIP
@@ -276,7 +276,7 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( "start = a:'a'", bytecodeDetails( [
-                18, 0, 2, 3, 22, 0, 3, 23, 1   // <expression>
+                23, 1, 18, 0, 2, 1, 22, 0, 3   // <expression>
             ] ) );
 
         } );
@@ -289,7 +289,7 @@ describe( "compiler pass |generateBytecode|", function () {
 
             expect( pass ).to.changeAST( "start = $'a'", bytecodeDetails( [
                 5,                            // PUSH_CURR_POS
-                18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                23, 1, 18, 0, 2, 1, 22, 0, 3, // <expression>
                 15, 2, 1,                     // IF_NOT_ERROR
                 6,                            //   * POP
                 12,                           //     TEXT
@@ -309,7 +309,7 @@ describe( "compiler pass |generateBytecode|", function () {
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
                 5,                            // PUSH_CURR_POS
                 28,                           // SILENT_FAILS_ON
-                18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                23, 1, 18, 0, 2, 1, 22, 0, 3, // <expression>
                 29,                           // SILENT_FAILS_OFF
                 15, 3, 3,                     // IF_NOT_ERROR
                 6,                            //   * POP
@@ -342,7 +342,7 @@ describe( "compiler pass |generateBytecode|", function () {
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
                 5,                            // PUSH_CURR_POS
                 28,                           // SILENT_FAILS_ON
-                18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                23, 1, 18, 0, 2, 1, 22, 0, 3, // <expression>
                 29,                           // SILENT_FAILS_OFF
                 14, 3, 3,                     // IF_ERROR
                 6,                            //   * POP
@@ -373,7 +373,7 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                23, 1, 18, 0, 2, 1, 22, 0, 3, // <expression>
                 14, 2, 0,                     // IF_ERROR
                 6,                            //   * POP
                 2                             //     PUSH_NULL
@@ -400,10 +400,10 @@ describe( "compiler pass |generateBytecode|", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
                 4,                            // PUSH_EMPTY_ARRAY
-                18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                23, 1, 18, 0, 2, 1, 22, 0, 3, // <expression>
                 16, 10,                       // WHILE_NOT_ERROR
                 10,                           //   * APPEND
-                18, 0, 2, 3, 22, 0, 3, 23, 1, //     <expression>
+                23, 1, 18, 0, 2, 1, 22, 0, 3, //     <expression>
                 6                             // POP
             ] ) );
 
@@ -428,11 +428,11 @@ describe( "compiler pass |generateBytecode|", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
                 4,                            // PUSH_EMPTY_ARRAY
-                18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                23, 1, 18, 0, 2, 1, 22, 0, 3, // <expression>
                 15, 13, 3,                    // IF_NOT_ERROR
                 16, 10,                       //   * WHILE_NOT_ERROR
                 10,                           //       * APPEND
-                18, 0, 2, 3, 22, 0, 3, 23, 1, //         <expression>
+                23, 1, 18, 0, 2, 1, 22, 0, 3, //         <expression>
                 6,                            //     POP
                 6,                            //   * POP
                 6,                            //     POP
@@ -457,7 +457,7 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( "start = ('a')", bytecodeDetails( [
-                18, 0, 2, 3, 22, 0, 3, 23, 1   // <expression>
+                23, 1, 18, 0, 2, 1, 22, 0, 3   // <expression>
             ] ) );
 
         } );
@@ -503,11 +503,11 @@ describe( "compiler pass |generateBytecode|", function () {
 
                 expect( pass ).to.changeAST( grammar, bytecodeDetails( [
                     5,                            // PUSH_CURR_POS
-                    18, 0, 2, 3, 22, 0, 3, 23, 1, // <elements[0]>
+                    23, 1, 18, 0, 2, 1, 22, 0, 3, // <elements[0]>
                     15, 57, 3,                    // IF_NOT_ERROR
-                    18, 2, 2, 3, 22, 2, 3, 23, 3, //   * <elements[1]>
+                    23, 3, 18, 2, 2, 1, 22, 2, 3, //   * <elements[1]>
                     15, 41, 4,                    //     IF_NOT_ERROR
-                    18, 4, 2, 3, 22, 4, 3, 23, 5, //       * <elements[2]>
+                    23, 5, 18, 4, 2, 1, 22, 4, 3, //       * <elements[2]>
                     15, 25, 4,                    //         IF_NOT_ERROR
                     25,                           //           * UPDATE_SAVED_POS
                     26, 6, 0, 3, 2, 1, 0,         //             CALL
@@ -592,11 +592,11 @@ describe( "compiler pass |generateBytecode|", function () {
 
                 expect( pass ).to.changeAST( grammar, bytecodeDetails( [
                     5,                            // PUSH_CURR_POS
-                    18, 0, 2, 3, 22, 0, 3, 23, 1, // <elements[0]>
+                    23, 1, 18, 0, 2, 1, 22, 0, 3, // <elements[0]>
                     15, 57, 3,                    // IF_NOT_ERROR
-                    18, 2, 2, 3, 22, 2, 3, 23, 3, //   * <elements[1]>
+                    23, 3, 18, 2, 2, 1, 22, 2, 3, //   * <elements[1]>
                     15, 41, 4,                    //     IF_NOT_ERROR
-                    18, 4, 2, 3, 22, 4, 3, 23, 5, //       * <elements[2]>
+                    23, 5, 18, 4, 2, 1, 22, 4, 3, //       * <elements[2]>
                     15, 25, 4,                    //         IF_NOT_ERROR
                     25,                           //           * UPDATE_SAVED_POS
                     26, 6, 0, 3, 2, 1, 0,         //             CALL
@@ -691,10 +691,10 @@ describe( "compiler pass |generateBytecode|", function () {
             it( "generates correct bytecode", function () {
 
                 expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                    18, 0, 2, 3,   // MATCH_STRING
+                    23, 1,         // EXPECT <1>
+                    18, 0, 2, 1,   // MATCH_STRING <0>
                     22, 0,         //   * ACCEPT_STRING
-                    3,             //   * PUSH_FAILED
-                    23, 1          //     EXPECT <1>
+                    3              //   * PUSH_FAILED
                 ] ) );
 
             } );
@@ -717,10 +717,10 @@ describe( "compiler pass |generateBytecode|", function () {
             it( "generates correct bytecode", function () {
 
                 expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                    19, 0, 2, 3,   // MATCH_STRING_IC
+                    23, 1,         // EXPECT <1>
+                    19, 0, 2, 1,   // MATCH_STRING_IC <0>
                     21, 1,         //   * ACCEPT_N
-                    3,             //   * PUSH_FAILED
-                    23, 1          //     EXPECT <1>
+                    3              //   * PUSH_FAILED
                 ] ) );
 
             } );
@@ -743,10 +743,10 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( "start = [a]", bytecodeDetails( [
-                20, 0, 2, 3,   // MATCH_REGEXP
+                23, 1,         // EXPECT <1>
+                20, 0, 2, 1,   // MATCH_REGEXP <0>
                 21, 1,         //   * ACCEPT_N
-                3,             //   * PUSH_FAILED
-                23, 1          //     EXPECT <1>
+                3              //   * PUSH_FAILED
             ] ) );
 
         } );
@@ -812,10 +812,10 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates bytecode", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                17, 2, 3,   // MATCH_ANY
+                23, 0,      // EXPECT <0>
+                17, 2, 1,   // MATCH_ANY
                 21, 1,      //   * ACCEPT_N
-                3,          //   * PUSH_FAILED
-                23, 0       //     EXPECT <0>
+                3           //   * PUSH_FAILED
             ] ) );
 
         } );

--- a/test/spec/unit/compiler/passes/generate-bytecode.spec.js
+++ b/test/spec/unit/compiler/passes/generate-bytecode.spec.js
@@ -34,9 +34,9 @@ describe( "compiler pass |generateBytecode|", function () {
                 "c = 'c'"
             ].join( "\n" ), {
                 rules: [
-                    { bytecode: [ 18, 0, 2, 2, 22, 0, 23, 1 ] },
-                    { bytecode: [ 18, 2, 2, 2, 22, 2, 23, 3 ] },
-                    { bytecode: [ 18, 4, 2, 2, 22, 4, 23, 5 ] }
+                    { bytecode: [ 18, 0, 2, 3, 22, 0, 3, 23, 1 ] },
+                    { bytecode: [ 18, 2, 2, 3, 22, 2, 3, 23, 3 ] },
+                    { bytecode: [ 18, 4, 2, 3, 22, 4, 3, 23, 5 ] }
                 ]
             } );
 
@@ -66,7 +66,7 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( "start = 'a'", bytecodeDetails( [
-                18, 0, 2, 2, 22, 0, 23, 1   // <expression>
+                18, 0, 2, 3, 22, 0, 3, 23, 1   // <expression>
             ] ) );
 
         } );
@@ -80,11 +80,12 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                28,                          // SILENT_FAILS_ON
-                18, 1, 2, 2, 22, 1, 23, 2,   // <expression>
-                29,                          // SILENT_FAILS_OFF
-                14, 2, 0,                    // IF_ERROR
-                23, 0                        //   * FAIL
+                28,                           // SILENT_FAILS_ON
+                18, 1, 2, 3, 22, 1, 3, 23, 2, // <expression>
+                29,                           // SILENT_FAILS_OFF
+                14, 3, 0,                     // IF_ERROR
+                3,                            //   * PUSH_FAILED
+                23, 0                         //     EXPECT <0>
             ] ) );
 
         } );
@@ -106,13 +107,13 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( "start = 'a' / 'b' / 'c'", bytecodeDetails( [
-                18, 0, 2, 2, 22, 0, 23, 1,   // <alternatives[0]>
-                14, 21, 0,                   // IF_ERROR
-                6,                           //   * POP
-                18, 2, 2, 2, 22, 2, 23, 3,   //     <alternatives[1]>
-                14, 9, 0,                    //     IF_ERROR
-                6,                           //       * POP
-                18, 4, 2, 2, 22, 4, 23, 5    //         <alternatives[2]>
+                18, 0, 2, 3, 22, 0, 3, 23, 1, // <alternatives[0]>
+                14, 23, 0,                    // IF_ERROR
+                6,                            //   * POP
+                18, 2, 2, 3, 22, 2, 3, 23, 3, //     <alternatives[1]>
+                14, 10, 0,                    //     IF_ERROR
+                6,                            //       * POP
+                18, 4, 2, 3, 22, 4, 3, 23, 5  //         <alternatives[2]>
             ] ) );
 
         } );
@@ -128,12 +129,12 @@ describe( "compiler pass |generateBytecode|", function () {
             it( "generates correct bytecode", function () {
 
                 expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                    5,                           // PUSH_CURR_POS
-                    18, 0, 2, 2, 22, 0, 23, 1,   // <expression>
-                    15, 6, 0,                    // IF_NOT_ERROR
-                    24, 1,                       //   * LOAD_SAVED_POS
-                    26, 2, 1, 0,                 //     CALL
-                    9                            // NIP
+                    5,                            // PUSH_CURR_POS
+                    18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                    15, 6, 0,                     // IF_NOT_ERROR
+                    24, 1,                        //   * LOAD_SAVED_POS
+                    26, 2, 1, 0,                  //     CALL
+                    9                             // NIP
                 ] ) );
 
             } );
@@ -157,12 +158,12 @@ describe( "compiler pass |generateBytecode|", function () {
             it( "generates correct bytecode", function () {
 
                 expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                    5,                           // PUSH_CURR_POS
-                    18, 0, 2, 2, 22, 0, 23, 1,   // <expression>
-                    15, 7, 0,                    // IF_NOT_ERROR
-                    24, 1,                       //   * LOAD_SAVED_POS
-                    26, 2, 1, 1, 0,              //     CALL
-                    9                            // NIP
+                    5,                            // PUSH_CURR_POS
+                    18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                    15, 7, 0,                     // IF_NOT_ERROR
+                    24, 1,                        //   * LOAD_SAVED_POS
+                    26, 2, 1, 1, 0,               //     CALL
+                    9                             // NIP
                 ] ) );
 
             } );
@@ -186,24 +187,24 @@ describe( "compiler pass |generateBytecode|", function () {
             it( "generates correct bytecode", function () {
 
                 expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                    5,                           // PUSH_CURR_POS
-                    18, 0, 2, 2, 22, 0, 23, 1,   // <elements[0]>
-                    15, 39, 3,                   // IF_NOT_ERROR
-                    18, 2, 2, 2, 22, 2, 23, 3,   //   * <elements[1]>
-                    15, 24, 4,                   //     IF_NOT_ERROR
-                    18, 4, 2, 2, 22, 4, 23, 5,   //       * <elements[2]>
-                    15, 9, 4,                   //         IF_NOT_ERROR
-                    24, 3,                       //           * LOAD_SAVED_POS
-                    26, 6, 4, 3, 2, 1, 0,        //             CALL <6>
-                    8, 3,                        //           * POP_N
-                    7,                           //             POP_CURR_POS
-                    3,                           //             PUSH_FAILED
-                    8, 2,                        //       * POP_N
-                    7,                           //         POP_CURR_POS
-                    3,                           //         PUSH_FAILED
-                    6,                           //   * POP
-                    7,                           //     POP_CURR_POS
-                    3                            //     PUSH_FAILED
+                    5,                            // PUSH_CURR_POS
+                    18, 0, 2, 3, 22, 0, 3, 23, 1, // <elements[0]>
+                    15, 41, 3,                    // IF_NOT_ERROR
+                    18, 2, 2, 3, 22, 2, 3, 23, 3, //   * <elements[1]>
+                    15, 25, 4,                    //     IF_NOT_ERROR
+                    18, 4, 2, 3, 22, 4, 3, 23, 5, //       * <elements[2]>
+                    15, 9, 4,                     //         IF_NOT_ERROR
+                    24, 3,                        //           * LOAD_SAVED_POS
+                    26, 6, 4, 3, 2, 1, 0,         //             CALL <6>
+                    8, 3,                         //           * POP_N
+                    7,                            //             POP_CURR_POS
+                    3,                            //             PUSH_FAILED
+                    8, 2,                         //       * POP_N
+                    7,                            //         POP_CURR_POS
+                    3,                            //         PUSH_FAILED
+                    6,                            //   * POP
+                    7,                            //     POP_CURR_POS
+                    3                             //     PUSH_FAILED
                 ] ) );
 
             } );
@@ -233,24 +234,24 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                5,                           // PUSH_CURR_POS
-                18, 0, 2, 2, 22, 0, 23, 1,   // <elements[0]>
-                15, 33, 3,                   // IF_NOT_ERROR
-                18, 2, 2, 2, 22, 2, 23, 3,   //   * <elements[1]>
-                15, 18, 4,                   //     IF_NOT_ERROR
-                18, 4, 2, 2, 22, 4, 23, 5,   //       * <elements[2]>
-                15, 3, 4,                    //         IF_NOT_ERROR
-                11, 3,                       //           * WRAP
-                9,                           //             NIP
-                8, 3,                        //           * POP_N
-                7,                           //             POP_CURR_POS
-                3,                           //             PUSH_FAILED
-                8, 2,                        //       * POP_N
-                7,                           //         POP_CURR_POS
-                3,                           //         PUSH_FAILED
-                6,                           //   * POP
-                7,                           //     POP_CURR_POS
-                3                            //     PUSH_FAILED
+                5,                            // PUSH_CURR_POS
+                18, 0, 2, 3, 22, 0, 3, 23, 1, // <elements[0]>
+                15, 35, 3,                    // IF_NOT_ERROR
+                18, 2, 2, 3, 22, 2, 3, 23, 3, //   * <elements[1]>
+                15, 19, 4,                    //     IF_NOT_ERROR
+                18, 4, 2, 3, 22, 4, 3, 23, 5, //       * <elements[2]>
+                15, 3, 4,                     //         IF_NOT_ERROR
+                11, 3,                        //           * WRAP
+                9,                            //             NIP
+                8, 3,                         //           * POP_N
+                7,                            //             POP_CURR_POS
+                3,                            //             PUSH_FAILED
+                8, 2,                         //       * POP_N
+                7,                            //         POP_CURR_POS
+                3,                            //         PUSH_FAILED
+                6,                            //   * POP
+                7,                            //     POP_CURR_POS
+                3                             //     PUSH_FAILED
             ] ) );
 
         } );
@@ -275,7 +276,7 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( "start = a:'a'", bytecodeDetails( [
-                18, 0, 2, 2, 22, 0, 23, 1   // <expression>
+                18, 0, 2, 3, 22, 0, 3, 23, 1   // <expression>
             ] ) );
 
         } );
@@ -287,12 +288,12 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( "start = $'a'", bytecodeDetails( [
-                5,                           // PUSH_CURR_POS
-                18, 0, 2, 2, 22, 0, 23, 1,   // <expression>
-                15, 2, 1,                    // IF_NOT_ERROR
-                6,                           //   * POP
-                12,                          //     TEXT
-                9                            //   * NIP
+                5,                            // PUSH_CURR_POS
+                18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                15, 2, 1,                     // IF_NOT_ERROR
+                6,                            //   * POP
+                12,                           //     TEXT
+                9                             //   * NIP
             ] ) );
 
         } );
@@ -306,17 +307,17 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                5,                           // PUSH_CURR_POS
-                28,                          // SILENT_FAILS_ON
-                18, 0, 2, 2, 22, 0, 23, 1,   // <expression>
-                29,                          // SILENT_FAILS_OFF
-                15, 3, 3,                    // IF_NOT_ERROR
-                6,                           //   * POP
-                7,                           //     POP_CURR_POS
-                1,                           //     PUSH_UNDEFINED
-                6,                           //   * POP
-                6,                           //     POP
-                3                            //     PUSH_FAILED
+                5,                            // PUSH_CURR_POS
+                28,                           // SILENT_FAILS_ON
+                18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                29,                           // SILENT_FAILS_OFF
+                15, 3, 3,                     // IF_NOT_ERROR
+                6,                            //   * POP
+                7,                            //     POP_CURR_POS
+                1,                            //     PUSH_UNDEFINED
+                6,                            //   * POP
+                6,                            //     POP
+                3                             //     PUSH_FAILED
             ] ) );
 
         } );
@@ -339,17 +340,17 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                5,                           // PUSH_CURR_POS
-                28,                          // SILENT_FAILS_ON
-                18, 0, 2, 2, 22, 0, 23, 1,   // <expression>
-                29,                          // SILENT_FAILS_OFF
-                14, 3, 3,                    // IF_ERROR
-                6,                           //   * POP
-                6,                           //     POP
-                1,                           //     PUSH_UNDEFINED
-                6,                           //   * POP
-                7,                           //     POP_CURR_POS
-                3                            //     PUSH_FAILED
+                5,                            // PUSH_CURR_POS
+                28,                           // SILENT_FAILS_ON
+                18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                29,                           // SILENT_FAILS_OFF
+                14, 3, 3,                     // IF_ERROR
+                6,                            //   * POP
+                6,                            //     POP
+                1,                            //     PUSH_UNDEFINED
+                6,                            //   * POP
+                7,                            //     POP_CURR_POS
+                3                             //     PUSH_FAILED
             ] ) );
 
         } );
@@ -372,10 +373,10 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                18, 0, 2, 2, 22, 0, 23, 1,   // <expression>
-                14, 2, 0,                    // IF_ERROR
-                6,                           //   * POP
-                2                            //     PUSH_NULL
+                18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                14, 2, 0,                     // IF_ERROR
+                6,                            //   * POP
+                2                             //     PUSH_NULL
             ] ) );
 
         } );
@@ -398,12 +399,12 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                4,                           // PUSH_EMPTY_ARRAY
-                18, 0, 2, 2, 22, 0, 23, 1,   // <expression>
-                16, 9,                       // WHILE_NOT_ERROR
-                10,                          //   * APPEND
-                18, 0, 2, 2, 22, 0, 23, 1,   //     <expression>
-                6                            // POP
+                4,                            // PUSH_EMPTY_ARRAY
+                18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                16, 10,                       // WHILE_NOT_ERROR
+                10,                           //   * APPEND
+                18, 0, 2, 3, 22, 0, 3, 23, 1, //     <expression>
+                6                             // POP
             ] ) );
 
         } );
@@ -426,16 +427,16 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                4,                           // PUSH_EMPTY_ARRAY
-                18, 0, 2, 2, 22, 0, 23, 1,   // <expression>
-                15, 12, 3,                   // IF_NOT_ERROR
-                16, 9,                       //   * WHILE_NOT_ERROR
-                10,                          //       * APPEND
-                18, 0, 2, 2, 22, 0, 23, 1,   //         <expression>
-                6,                           //     POP
-                6,                           //   * POP
-                6,                           //     POP
-                3                            //     PUSH_FAILED
+                4,                            // PUSH_EMPTY_ARRAY
+                18, 0, 2, 3, 22, 0, 3, 23, 1, // <expression>
+                15, 13, 3,                    // IF_NOT_ERROR
+                16, 10,                       //   * WHILE_NOT_ERROR
+                10,                           //       * APPEND
+                18, 0, 2, 3, 22, 0, 3, 23, 1, //         <expression>
+                6,                            //     POP
+                6,                            //   * POP
+                6,                            //     POP
+                3                             //     PUSH_FAILED
             ] ) );
 
         } );
@@ -456,7 +457,7 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( "start = ('a')", bytecodeDetails( [
-                18, 0, 2, 2, 22, 0, 23, 1   // <expression>
+                18, 0, 2, 3, 22, 0, 3, 23, 1   // <expression>
             ] ) );
 
         } );
@@ -501,35 +502,35 @@ describe( "compiler pass |generateBytecode|", function () {
             it( "generates correct bytecode", function () {
 
                 expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                    5,                           // PUSH_CURR_POS
-                    18, 0, 2, 2, 22, 0, 23, 1,   // <elements[0]>
-                    15, 55, 3,                   // IF_NOT_ERROR
-                    18, 2, 2, 2, 22, 2, 23, 3,   //   * <elements[1]>
-                    15, 40, 4,                   //     IF_NOT_ERROR
-                    18, 4, 2, 2, 22, 4, 23, 5,   //       * <elements[2]>
-                    15, 25, 4,                   //         IF_NOT_ERROR
-                    25,                          //           * UPDATE_SAVED_POS
-                    26, 6, 0, 3, 2, 1, 0,        //             CALL
-                    13, 2, 2,                    //             IF
-                    6,                           //               * POP
-                    1,                           //                 PUSH_UNDEFINED
-                    6,                           //               * POP
-                    3,                           //                 PUSH_FAILED
-                    15, 3, 4,                    //             IF_NOT_ERROR
-                    11, 4,                       //               * WRAP
-                    9,                           //                 NIP
-                    8, 4,                        //               * POP_N
-                    7,                           //                 POP_CURR_POS
-                    3,                           //                 PUSH_FAILED
-                    8, 3,                        //           * POP_N
-                    7,                           //             POP_CURR_POS
-                    3,                           //             PUSH_FAILED
-                    8, 2,                        //       * POP_N
-                    7,                           //         POP_CURR_POS
-                    3,                           //         PUSH_FAILED
-                    6,                           //   * POP
-                    7,                           //     POP_CURR_POS
-                    3                            //     PUSH_FAILED
+                    5,                            // PUSH_CURR_POS
+                    18, 0, 2, 3, 22, 0, 3, 23, 1, // <elements[0]>
+                    15, 57, 3,                    // IF_NOT_ERROR
+                    18, 2, 2, 3, 22, 2, 3, 23, 3, //   * <elements[1]>
+                    15, 41, 4,                    //     IF_NOT_ERROR
+                    18, 4, 2, 3, 22, 4, 3, 23, 5, //       * <elements[2]>
+                    15, 25, 4,                    //         IF_NOT_ERROR
+                    25,                           //           * UPDATE_SAVED_POS
+                    26, 6, 0, 3, 2, 1, 0,         //             CALL
+                    13, 2, 2,                     //             IF
+                    6,                            //               * POP
+                    1,                            //                 PUSH_UNDEFINED
+                    6,                            //               * POP
+                    3,                            //                 PUSH_FAILED
+                    15, 3, 4,                     //             IF_NOT_ERROR
+                    11, 4,                        //               * WRAP
+                    9,                            //                 NIP
+                    8, 4,                         //               * POP_N
+                    7,                            //                 POP_CURR_POS
+                    3,                            //                 PUSH_FAILED
+                    8, 3,                         //           * POP_N
+                    7,                            //             POP_CURR_POS
+                    3,                            //             PUSH_FAILED
+                    8, 2,                         //       * POP_N
+                    7,                            //         POP_CURR_POS
+                    3,                            //         PUSH_FAILED
+                    6,                            //   * POP
+                    7,                            //     POP_CURR_POS
+                    3                             //     PUSH_FAILED
                 ] ) );
 
             } );
@@ -590,35 +591,35 @@ describe( "compiler pass |generateBytecode|", function () {
             it( "generates correct bytecode", function () {
 
                 expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                    5,                           // PUSH_CURR_POS
-                    18, 0, 2, 2, 22, 0, 23, 1,   // <elements[0]>
-                    15, 55, 3,                   // IF_NOT_ERROR
-                    18, 2, 2, 2, 22, 2, 23, 3,   //   * <elements[1]>
-                    15, 40, 4,                   //     IF_NOT_ERROR
-                    18, 4, 2, 2, 22, 4, 23, 5,   //       * <elements[2]>
-                    15, 25, 4,                   //         IF_NOT_ERROR
-                    25,                          //           * UPDATE_SAVED_POS
-                    26, 6, 0, 3, 2, 1, 0,        //             CALL
-                    13, 2, 2,                    //             IF
-                    6,                           //               * POP
-                    3,                           //                 PUSH_FAILED
-                    6,                           //               * POP
-                    1,                           //                 PUSH_UNDEFINED
-                    15, 3, 4,                    //             IF_NOT_ERROR
-                    11, 4,                       //               * WRAP
-                    9,                           //                 NIP
-                    8, 4,                        //               * POP_N
-                    7,                           //                 POP_CURR_POS
-                    3,                           //                 PUSH_FAILED
-                    8, 3,                        //           * POP_N
-                    7,                           //             POP_CURR_POS
-                    3,                           //             PUSH_FAILED
-                    8, 2,                        //       * POP_N
-                    7,                           //         POP_CURR_POS
-                    3,                           //         PUSH_FAILED
-                    6,                           //   * POP
-                    7,                           //     POP_CURR_POS
-                    3                            //     PUSH_FAILED
+                    5,                            // PUSH_CURR_POS
+                    18, 0, 2, 3, 22, 0, 3, 23, 1, // <elements[0]>
+                    15, 57, 3,                    // IF_NOT_ERROR
+                    18, 2, 2, 3, 22, 2, 3, 23, 3, //   * <elements[1]>
+                    15, 41, 4,                    //     IF_NOT_ERROR
+                    18, 4, 2, 3, 22, 4, 3, 23, 5, //       * <elements[2]>
+                    15, 25, 4,                    //         IF_NOT_ERROR
+                    25,                           //           * UPDATE_SAVED_POS
+                    26, 6, 0, 3, 2, 1, 0,         //             CALL
+                    13, 2, 2,                     //             IF
+                    6,                            //               * POP
+                    3,                            //                 PUSH_FAILED
+                    6,                            //               * POP
+                    1,                            //                 PUSH_UNDEFINED
+                    15, 3, 4,                     //             IF_NOT_ERROR
+                    11, 4,                        //               * WRAP
+                    9,                            //                 NIP
+                    8, 4,                         //               * POP_N
+                    7,                            //                 POP_CURR_POS
+                    3,                            //                 PUSH_FAILED
+                    8, 3,                         //           * POP_N
+                    7,                            //             POP_CURR_POS
+                    3,                            //             PUSH_FAILED
+                    8, 2,                         //       * POP_N
+                    7,                            //         POP_CURR_POS
+                    3,                            //         PUSH_FAILED
+                    6,                            //   * POP
+                    7,                            //     POP_CURR_POS
+                    3                             //     PUSH_FAILED
                 ] ) );
 
             } );
@@ -690,9 +691,10 @@ describe( "compiler pass |generateBytecode|", function () {
             it( "generates correct bytecode", function () {
 
                 expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                    18, 0, 2, 2,   // MATCH_STRING
+                    18, 0, 2, 3,   // MATCH_STRING
                     22, 0,         //   * ACCEPT_STRING
-                    23, 1          //   * FAIL
+                    3,             //   * PUSH_FAILED
+                    23, 1          //     EXPECT <1>
                 ] ) );
 
             } );
@@ -715,9 +717,10 @@ describe( "compiler pass |generateBytecode|", function () {
             it( "generates correct bytecode", function () {
 
                 expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                    19, 0, 2, 2,   // MATCH_STRING_IC
+                    19, 0, 2, 3,   // MATCH_STRING_IC
                     21, 1,         //   * ACCEPT_N
-                    23, 1          //   * FAIL
+                    3,             //   * PUSH_FAILED
+                    23, 1          //     EXPECT <1>
                 ] ) );
 
             } );
@@ -740,9 +743,10 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates correct bytecode", function () {
 
             expect( pass ).to.changeAST( "start = [a]", bytecodeDetails( [
-                20, 0, 2, 2,   // MATCH_REGEXP
+                20, 0, 2, 3,   // MATCH_REGEXP
                 21, 1,         //   * ACCEPT_N
-                23, 1          //   * FAIL
+                3,             //   * PUSH_FAILED
+                23, 1          //     EXPECT <1>
             ] ) );
 
         } );
@@ -808,9 +812,10 @@ describe( "compiler pass |generateBytecode|", function () {
         it( "generates bytecode", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
-                17, 2, 2,   // MATCH_ANY
+                17, 2, 3,   // MATCH_ANY
                 21, 1,      //   * ACCEPT_N
-                23, 0       //   * FAIL
+                3,          //   * PUSH_FAILED
+                23, 0       //     EXPECT <0>
             ] ) );
 
         } );

--- a/test/spec/unit/compiler/passes/generate-bytecode.spec.js
+++ b/test/spec/unit/compiler/passes/generate-bytecode.spec.js
@@ -306,9 +306,9 @@ describe( "compiler pass |generateBytecode|", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
                 5,                            // PUSH_CURR_POS
-                28,                           // SILENT_FAILS_ON
+                38,                           // EXPECT_NS_BEGIN
                 23, 1, 18, 0, 2, 1, 22, 0, 3, // <expression>
-                29,                           // SILENT_FAILS_OFF
+                39,                           // EXPECT_NS_END
                 15, 3, 3,                     // IF_NOT_ERROR
                 6,                            //   * POP
                 7,                            //     POP_CURR_POS
@@ -339,9 +339,9 @@ describe( "compiler pass |generateBytecode|", function () {
 
             expect( pass ).to.changeAST( grammar, bytecodeDetails( [
                 5,                            // PUSH_CURR_POS
-                28,                           // SILENT_FAILS_ON
+                38,                           // EXPECT_NS_BEGIN
                 23, 1, 18, 0, 2, 1, 22, 0, 3, // <expression>
-                29,                           // SILENT_FAILS_OFF
+                39,                           // EXPECT_NS_END
                 14, 3, 3,                     // IF_ERROR
                 6,                            //   * POP
                 6,                            //     POP

--- a/test/spec/unit/compiler/passes/generate-bytecode.spec.js
+++ b/test/spec/unit/compiler/passes/generate-bytecode.spec.js
@@ -308,7 +308,7 @@ describe( "compiler pass |generateBytecode|", function () {
                 5,                            // PUSH_CURR_POS
                 38,                           // EXPECT_NS_BEGIN
                 23, 1, 18, 0, 2, 1, 22, 0, 3, // <expression>
-                39,                           // EXPECT_NS_END
+                39, 0,                        // EXPECT_NS_END <false>
                 15, 3, 3,                     // IF_NOT_ERROR
                 6,                            //   * POP
                 7,                            //     POP_CURR_POS
@@ -341,7 +341,7 @@ describe( "compiler pass |generateBytecode|", function () {
                 5,                            // PUSH_CURR_POS
                 38,                           // EXPECT_NS_BEGIN
                 23, 1, 18, 0, 2, 1, 22, 0, 3, // <expression>
-                39,                           // EXPECT_NS_END
+                39, 1,                        // EXPECT_NS_END <true>
                 14, 3, 3,                     // IF_ERROR
                 6,                            //   * POP
                 6,                            //     POP


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Absolutely correct fix is very difficult, and shall include uncommon methods of merge of the expected messages for compilation of lungs for perception of error messages. However, as still did not complain of errors (except this issue), implementation of complete fix can be postponed.

This fix introduces negative expectations and also expectations from positive lookaheads. For grammar
```pegjs
start = !'a';
```
and input `a` error will be
```
Expected not "a", but "a" found
```
This is still slightly incorrect, because if you type character, other than "a", then there will be other parse error, but it nevertheless is better, than being earlier
```
Expected , but "a" found
```
Ideally such grammar must not compile at all, because it have contradictory requirements: on the same place at the same time are expected a character "a" and EOF. I have prototype, but they will be ready not soon.