### PR TITLE
Use chai-like instead of own properties matcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "babelify": "8.0.0",
         "browserify": "14.5.0",
         "chai": "4.1.2",
+        "chai-like": "^1.0.0",
         "coveralls": "3.0.0",
         "dedent": "0.7.0",
         "del": "3.0.0",

--- a/test/spec/unit/compiler/passes/helpers.js
+++ b/test/spec/unit/compiler/passes/helpers.js
@@ -4,55 +4,14 @@ const parser = require( "pegjs-dev" ).parser;
 
 module.exports = function ( chai, utils ) {
 
+    chai.use( require( "chai-like" ) );
+
     const Assertion = chai.Assertion;
 
     Assertion.addMethod( "changeAST", function ( grammar, props, options, additionalRuleProps ) {
 
         options = typeof options !== "undefined" ? options : {};
         additionalRuleProps = typeof additionalRuleProps !== "undefined" ? additionalRuleProps : { reportFailures: true };
-
-        function matchProps( value, props ) {
-
-            function isObject( value ) {
-
-                return value !== null && typeof value === "object";
-
-            }
-
-            if ( Array.isArray( props ) ) {
-
-                if ( ! Array.isArray( value ) ) return false;
-                if ( value.length !== props.length ) return false;
-
-                for ( let i = 0; i < props.length; i++ ) {
-
-                    if ( ! matchProps( value[ i ], props[ i ] ) ) return false;
-
-                }
-
-                return true;
-
-            } else if ( isObject( props ) ) {
-
-                if ( ! isObject( value ) ) return false;
-
-                const keys = Object.keys( props );
-                for ( let i = 0; i < keys.length; i++ ) {
-
-                    const key = keys[ i ];
-
-                    if ( ! ( key in value ) ) return false;
-                    if ( ! matchProps( value[ key ], props[ key ] ) ) return false;
-
-                }
-
-                return true;
-
-            }
-
-            return value === props;
-
-        }
 
         const ast = parser.parse( grammar );
 
@@ -68,13 +27,7 @@ module.exports = function ( chai, utils ) {
 
         utils.flag( this, "object" )( ast, options );
 
-        this.assert(
-            matchProps( ast, props ),
-            "expected #{this} to change the AST to match #{exp} but #{act} was produced",
-            "expected #{this} to not change the AST to match #{exp}",
-            props,
-            ast
-        );
+        new Assertion( ast ).like( props );
 
     } );
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Own implementation of comparing cannot guarantee correctnesses as for it there are no tests. Besides, if necessary to repeat similar comparing it would be required to duplicate a code.