### PR TITLE
Fix last link in the TOC

### DIFF
--- a/docs/grammar/parsing-expression-types.md
+++ b/docs/grammar/parsing-expression-types.md
@@ -19,7 +19,7 @@ There are several types of parsing expressions, some of them containing subexpre
   * [expression<sub>1</sub> expression<sub>2</sub> ... expression<sub>n</sub>](#expression1-expression2---expressionn)
   * [expression { action }](#expression--action-)
   * [expression<sub>1</sub> / expression<sub>2</sub> / ... / expression<sub>n</sub>](#expression1--expression2----expressionn)
-  * [expression<sub>1</sub> @expression<sub>2</sub> ... expression<sub>n</sub>](#expression1--expression2---expressionn-1)
+  * [expression<sub>1</sub> @expression<sub>2</sub> ... expression<sub>n</sub>](#expression1--expression2----expressionn-1)
 
 #### "*literal*"<br>'*literal*'
 

--- a/docs/grammar/parsing-expression-types.md
+++ b/docs/grammar/parsing-expression-types.md
@@ -19,7 +19,7 @@ There are several types of parsing expressions, some of them containing subexpre
   * [expression<sub>1</sub> expression<sub>2</sub> ... expression<sub>n</sub>](#expression1-expression2---expressionn)
   * [expression { action }](#expression--action-)
   * [expression<sub>1</sub> / expression<sub>2</sub> / ... / expression<sub>n</sub>](#expression1--expression2----expressionn)
-  * [expression<sub>1</sub> @expression<sub>2</sub> ... expression<sub>n</sub>](#expression1--expression2---expressionn)
+  * [expression<sub>1</sub> @expression<sub>2</sub> ... expression<sub>n</sub>](#expression1--expression2---expressionn-1)
 
 #### "*literal*"<br>'*literal*'
 

--- a/docs/grammar/parsing-expression-types.md
+++ b/docs/grammar/parsing-expression-types.md
@@ -19,7 +19,7 @@ There are several types of parsing expressions, some of them containing subexpre
   * [expression<sub>1</sub> expression<sub>2</sub> ... expression<sub>n</sub>](#expression1-expression2---expressionn)
   * [expression { action }](#expression--action-)
   * [expression<sub>1</sub> / expression<sub>2</sub> / ... / expression<sub>n</sub>](#expression1--expression2----expressionn)
-  * [expression<sub>1</sub> @expression<sub>2</sub> ... expression<sub>n</sub>](#expression1--expression2----expressionn-1)
+  * [expression<sub>1</sub> @expression<sub>2</sub> ... expression<sub>n</sub>](#expression1-expression2---expressionn-1)
 
 #### "*literal*"<br>'*literal*'
 


### PR DESCRIPTION
There was a '-1' missing at the end of the link.

### PR type

<!--- What types of changes does your code introduce? (choose _yes_ or _no_): -->

- **Bug fix (non-breaking change which fixes an issue):** _yes_
- **New feature (non-breaking change which adds functionality):** _no_
- **Breaking change (fix or feature that would cause existing functionality to change):** _no_
- **Documentation change:** _yes_

### Prerequisites

<!-- Have you done the following (choose _yes_ or _no_): -->

- **I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document:** _no_ because, dude, it´s just a typo :-)
- **I have updated the documentation accordingly:** _yes_
- **I have added tests to cover my changes:** _no_

### Description

There was a '-1' missing at the end of the link.
