### PR TITLE
Partial match feature

### DIFF
--- a/packages/pegjs/lib/compiler/passes/generate-js.js
+++ b/packages/pegjs/lib/compiler/passes/generate-js.js
@@ -1604,15 +1604,27 @@ function generateJS( ast, session, options ) {
 
         }
 
+        if (options.partialMatch) {
+            parts.push([
+                "",
+                "  if (peg$result !== peg$FAILED) {",
+                "    return peg$result;",
+                "  } else {",
+            ].join('\n'));
+        } else {
+            parts.push([
+                "",
+                "  if (peg$result !== peg$FAILED && peg$currPos === input.length) {",
+                "    return peg$result;",
+                "  } else {",
+                "    if (peg$result !== peg$FAILED && peg$currPos < input.length) {",
+                "      peg$expect(peg$endExpectation());",
+                "    }",
+                "",
+            ].join('\n'));
+        }
+
         parts.push( [
-            "",
-            "  if (peg$result !== peg$FAILED && peg$currPos === input.length) {",
-            "    return peg$result;",
-            "  } else {",
-            "    if (peg$result !== peg$FAILED && peg$currPos < input.length) {",
-            "      peg$expect(peg$endExpectation());",
-            "    }",
-            "",
             "    throw peg$buildError();",
             "  }",
             "}",

--- a/packages/pegjs/lib/compiler/passes/generate-js.js
+++ b/packages/pegjs/lib/compiler/passes/generate-js.js
@@ -1604,15 +1604,18 @@ function generateJS( ast, session, options ) {
 
         }
 
-        if (options.partialMatch) {
-            parts.push([
+        if ( options.partialMatch ) {
+
+            parts.push( [
                 "",
                 "  if (peg$result !== peg$FAILED) {",
                 "    return peg$result;",
                 "  } else {",
-            ].join('\n'));
+            ].join( "\n" ) );
+
         } else {
-            parts.push([
+
+            parts.push( [
                 "",
                 "  if (peg$result !== peg$FAILED && peg$currPos === input.length) {",
                 "    return peg$result;",
@@ -1621,7 +1624,8 @@ function generateJS( ast, session, options ) {
                 "      peg$expect(peg$endExpectation());",
                 "    }",
                 "",
-            ].join('\n'));
+            ].join( "\n" ) );
+
         }
 
         parts.push( [


### PR DESCRIPTION
A partial match will succeed if at least the first part of input string matches: it does not fail in the case there are remaining unconsumed characters.

Note it fails in the case the start rule fails: if the grammar author want not to fail in this case, the start rule can be surrounded by a "?".

### PR type

- **Bug fix (non-breaking change which fixes an issue):** _no_
- **New feature (non-breaking change which adds functionality):** _yes_
- **Breaking change (fix or feature that would cause existing functionality to change):** _no_
- **Documentation change:** add an option either for grammar generation either for grammar execution

### Prerequisites

- **I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document:** _yes_
- **I have updated the documentation accordingly:** not yet
- **I have added tests to cover my changes:** not yet

### Description

The option `partialMatch` added in this commit fix the behaviour for every execution of the grammar. After thinking about it, I find it should be allowed to change this behaviour at execution time, so this PR should be changed accordingly (if this is shared by others).

Complete description in #645