### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/guides/javascript-api.md
+++ b/docs/guides/javascript-api.md
@@ -23,7 +23,7 @@ var ast = peg.parser.parse(grammar);
 // Create a new compiler session
 var session = new peg.compiler.Session( { warn: customLogger } );
 
-// Generate parser from PEG.js AST using an exisiting session 
+// Generate parser from PEG.js AST using an existing session 
 var parserA = peg.compiler.compile(ast, session);
 
 // Generate parser from the grammar source using a new session

--- a/test/api/pegjs-api.spec.js
+++ b/test/api/pegjs-api.spec.js
@@ -303,7 +303,7 @@ describe( "PEG.js API", function () {
         } );
 
         // The |format|, |exportVars|, and |dependencies| options are not tested
-        // becasue there is no meaningful way to thest their effects without turning
+        // because there is no meaningful way to test their effects without turning
         // this into an integration test.
 
         // The |plugins| option is tested in plugin API tests.

--- a/tools/impact/index.js
+++ b/tools/impact/index.js
@@ -67,7 +67,7 @@ function runBenchmark() {
     return parseFloat(
         exec( "node " + BENCHMARK_BIN )
 
-            // Split by table seprator, reverse and return the total bytes per second
+            // Split by table separator, reverse and return the total bytes per second
             .split( "│" )
             .reverse()[ 1 ]
 

--- a/tools/publish-dev/publish.js
+++ b/tools/publish-dev/publish.js
@@ -12,7 +12,7 @@ function publish( id ) {
     const directory = path.dirname( packagejson );
     const npmrc = path.join( directory, ".npmrc" );
 
-    // variabes
+    // variables
 
     const APP = require( "./package.json" ).name;
     const VERSION = require( packagejson ).version;

--- a/website/export.utils.js
+++ b/website/export.utils.js
@@ -17,7 +17,7 @@ const path = require( "path" );
 const FRESH_BUILD = process.argv.includes( "--fresh" );
 
 /**
- * A conveniant object that has the following merged:
+ * A convenient object that has the following merged:
  * 
  * - The `fs-extra-plus` module
  * - The `path` module
@@ -43,7 +43,7 @@ const fs = Object.assign( {}, path, fse, {
 } );
 
 /**
- * A bundler wrapper that simplfies bundler interaction across child process's via async functions.
+ * A bundler wrapper that simplifies bundler interaction across child process's via async functions.
  */
 
 const Bundler = {
@@ -147,7 +147,7 @@ function expand( p = ".", cwd = [ __dirname, ".." ] ) {
 }
 
 /**
- * A cache of the expaneded paths.
+ * A cache of the expanded paths.
  * 
  * @type {{ [key: string]: string }}
  */


### PR DESCRIPTION
There are small typos in:
- docs/guides/javascript-api.md
- test/api/pegjs-api.spec.js
- tools/impact/index.js
- tools/publish-dev/publish.js
- website/export.utils.js

Fixes:
- Should read `variables` rather than `variabes`.
- Should read `test` rather than `thest`.
- Should read `simplifies` rather than `simplfies`.
- Should read `separator` rather than `seprator`.
- Should read `expanded` rather than `expaneded`.
- Should read `existing` rather than `exisiting`.
- Should read `convenient` rather than `conveniant`.
- Should read `because` rather than `becasue`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md